### PR TITLE
Restore broken behavior: after uploading a new torrent its tracker stats must be updated

### DIFF
--- a/src/databases/mysql.rs
+++ b/src/databases/mysql.rs
@@ -344,7 +344,7 @@ impl Database for MysqlDatabase {
             INNER JOIN torrust_torrent_info ti ON tt.torrent_id = ti.torrent_id
             LEFT JOIN torrust_torrent_tracker_stats ts ON tt.torrent_id = ts.torrent_id
             WHERE title LIKE ?
-            GROUP BY torrent_id",
+            GROUP BY tt.torrent_id",
             category_filter_query
         );
 

--- a/src/databases/sqlite.rs
+++ b/src/databases/sqlite.rs
@@ -339,7 +339,7 @@ impl Database for SqliteDatabase {
             INNER JOIN torrust_torrent_info ti ON tt.torrent_id = ti.torrent_id
             LEFT JOIN torrust_torrent_tracker_stats ts ON tt.torrent_id = ts.torrent_id
             WHERE title LIKE ?
-            GROUP BY ts.torrent_id",
+            GROUP BY tt.torrent_id",
             category_filter_query
         );
 

--- a/src/routes/torrent.rs
+++ b/src/routes/torrent.rs
@@ -96,6 +96,12 @@ pub async fn upload_torrent(req: HttpRequest, payload: Multipart, app_data: WebA
         )
         .await?;
 
+    // update torrent tracker stats
+    let _ = app_data
+        .tracker
+        .update_torrent_tracker_stats(torrent_id, &torrent_request.torrent.info_hash())
+        .await;
+
     // whitelist info hash on tracker
     if let Err(e) = app_data
         .tracker

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -179,13 +179,19 @@ impl TrackerService {
     }
 
     pub async fn update_torrents(&self) -> Result<(), ServiceError> {
-        println!("Updating torrents..");
+        println!("Updating torrents ...");
         let torrents = self.database.get_all_torrents_compact().await?;
 
         for torrent in torrents {
-            let _ = self.get_torrent_info(torrent.torrent_id, &torrent.info_hash).await;
+            let _ = self
+                .update_torrent_tracker_stats(torrent.torrent_id, &torrent.info_hash)
+                .await;
         }
 
         Ok(())
+    }
+
+    pub async fn update_torrent_tracker_stats(&self, torrent_id: i64, info_hash: &str) -> Result<TorrentInfo, ServiceError> {
+        self.get_torrent_info(torrent_id, info_hash).await
     }
 }


### PR DESCRIPTION
When a new torrent is uploaded, we must update the tracker torrent stats in the `torrust_torrent_tracker_stats` table.

It worked from the UI but not for the [DB migration script](https://github.com/torrust/torrust-index-backend/pull/77) because the frontend makes a request to get the torrent info after the upload, and that endpoint updates the torrent tracker stats.

It must update the stats even if that endpoint is not called after uploading a new torrent.

### Tasks

- [x] After uploading a new torrent, update its tracker stats.
- [x] Change SQL query for torrent list result if we allow torrents without stats.

### Potencial refactors

- Extract `TrackerApiClient` from `TrackerService`
- Rename `TrackerService::get_torrent_info` to `TrackerService::update_torrent_tracker_stats`