### PR TITLE
Remove unused struct `NewTrackerKey`

### DIFF
--- a/src/models/tracker_key.rs
+++ b/src/models/tracker_key.rs
@@ -8,12 +8,6 @@ pub struct TrackerKey {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct NewTrackerKey {
-    pub key: String,
-    pub valid_until: Duration,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
 pub struct Duration {
     pub secs: i64,
     pub nanos: i64,


### PR DESCRIPTION
It was added because the tracker API was changed, but that change was reverted here:

https://github.com/torrust/torrust-tracker/pull/109

and it is not used anymore.