### PR TITLE
Add code owners for GitHub workflows

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+/.github/ @da2ce7 @josecelano @WarmBeer


### PR DESCRIPTION
@da2ce7 @josecelano @WarmBeer get notified when a PR changes the `.github` dir content.

@WarmBeer, we should also enable required reviews for PR and require approval from a code owner before the author can merge a pull request in the repository.

_"Optionally, you can choose to require reviews from code owners. If you do, any pull request that affects code with a code owner must be approved by that code owner before the pull request can be merged into the protected branch."_

See: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#require-pull-request-reviews-before-merging

I don't have permission to do it.