### PR TITLE
Update Visual Studio Code config to follow Tracker conventions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "streetsidesoftware.code-spell-checker",
+    "rust-lang.rust-analyzer"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,8 @@
 {
-    "[rust]": {
-        "editor.formatOnSave": true
-    },
-    "rust-analyzer.checkOnSave.command": "clippy",
+  "[rust]": {
+    "editor.formatOnSave": true
+  },
+  "rust-analyzer.checkOnSave.command": "clippy",
+  "rust-analyzer.checkOnSave.allTargets": true,
+  "rust-analyzer.checkOnSave.extraArgs": ["--", "-W", "clippy::pedantic"]
 }


### PR DESCRIPTION
Same configuration as https://github.com/torrust/torrust-tracker.

It does not enforce it in CI because there are a lot of errors for Clippy in `pedantic` mode.

```
cargo clippy --all-targets -- -D clippy::pedantic
```