### PR TITLE
E2E tests for API `category` routes

### DIFF
--- a/tests/e2e/asserts.rs
+++ b/tests/e2e/asserts.rs
@@ -1,10 +1,12 @@
 use crate::e2e::response::Response;
 
+// Text responses
+
 pub fn assert_response_title(response: &Response, title: &str) {
     let title_element = format!("<title>{title}</title>");
 
     assert!(
-        response.body.contains(&title),
+        response.body.contains(title),
         ":\n  response does not contain the title element: `\"{title_element}\"`."
     );
 }
@@ -13,6 +15,13 @@ pub fn assert_text_ok(response: &Response) {
     assert_eq!(response.status, 200);
     assert_eq!(response.content_type, "text/html; charset=utf-8");
 }
+
+pub fn _assert_text_bad_request(response: &Response) {
+    assert_eq!(response.status, 400);
+    assert_eq!(response.content_type, "text/plain; charset=utf-8");
+}
+
+// JSON responses
 
 pub fn assert_json_ok(response: &Response) {
     assert_eq!(response.status, 200);

--- a/tests/e2e/asserts.rs
+++ b/tests/e2e/asserts.rs
@@ -9,7 +9,12 @@ pub fn assert_response_title(response: &Response, title: &str) {
     );
 }
 
-pub fn assert_ok(response: &Response) {
+pub fn assert_text_ok(response: &Response) {
     assert_eq!(response.status, 200);
     assert_eq!(response.content_type, "text/html; charset=utf-8");
+}
+
+pub fn assert_json_ok(response: &Response) {
+    assert_eq!(response.status, 200);
+    assert_eq!(response.content_type, "application/json");
 }

--- a/tests/e2e/client.rs
+++ b/tests/e2e/client.rs
@@ -36,7 +36,8 @@ impl Client {
 
     /*
     pub async fn post(&self, path: &str) -> Response {
-        reqwest::Client::new().post(self.base_url(path).clone()).send().await.unwrap()
+        let response = reqwest::Client::new().post(self.base_url(path).clone()).send().await.unwrap();
+        Response::from(response).await
     }
 
     async fn delete(&self, path: &str) -> Response {

--- a/tests/e2e/client.rs
+++ b/tests/e2e/client.rs
@@ -18,6 +18,18 @@ impl Client {
         }
     }
 
+    pub async fn root(&self) -> Response {
+        self.get("", Query::empty()).await
+    }
+
+    pub async fn about(&self) -> Response {
+        self.get("about", Query::empty()).await
+    }
+
+    pub async fn license(&self) -> Response {
+        self.get("about/license", Query::empty()).await
+    }
+
     pub async fn get(&self, path: &str, params: Query) -> Response {
         self.get_request_with_query(path, params).await
     }

--- a/tests/e2e/connection_info.rs
+++ b/tests/e2e/connection_info.rs
@@ -1,4 +1,4 @@
-pub fn connection_with_no_token(bind_address: &str) -> ConnectionInfo {
+pub fn anonymous_connection(bind_address: &str) -> ConnectionInfo {
     ConnectionInfo::anonymous(bind_address)
 }
 

--- a/tests/e2e/env.rs
+++ b/tests/e2e/env.rs
@@ -1,0 +1,20 @@
+use crate::e2e::client::Client;
+use crate::e2e::connection_info::anonymous_connection;
+
+pub struct TestEnv {
+    pub authority: String,
+}
+
+impl TestEnv {
+    pub fn guess_client(&self) -> Client {
+        Client::new(anonymous_connection(&self.authority))
+    }
+}
+
+impl Default for TestEnv {
+    fn default() -> Self {
+        Self {
+            authority: "localhost:3000".to_string(),
+        }
+    }
+}

--- a/tests/e2e/env.rs
+++ b/tests/e2e/env.rs
@@ -6,7 +6,7 @@ pub struct TestEnv {
 }
 
 impl TestEnv {
-    pub fn guess_client(&self) -> Client {
+    pub fn unauthenticated_client(&self) -> Client {
         Client::new(anonymous_connection(&self.authority))
     }
 }

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -19,6 +19,7 @@
 mod asserts;
 mod client;
 mod connection_info;
+pub mod env;
 mod http;
 mod response;
 mod routes;

--- a/tests/e2e/routes/about.rs
+++ b/tests/e2e/routes/about.rs
@@ -4,7 +4,7 @@ use crate::e2e::env::TestEnv;
 #[tokio::test]
 #[cfg_attr(not(feature = "e2e-tests"), ignore)]
 async fn it_should_load_the_about_page_with_information_about_the_api() {
-    let client = TestEnv::default().guess_client();
+    let client = TestEnv::default().unauthenticated_client();
 
     let response = client.about().await;
 
@@ -15,7 +15,7 @@ async fn it_should_load_the_about_page_with_information_about_the_api() {
 #[tokio::test]
 #[cfg_attr(not(feature = "e2e-tests"), ignore)]
 async fn it_should_load_the_license_page_at_the_api_entrypoint() {
-    let client = TestEnv::default().guess_client();
+    let client = TestEnv::default().unauthenticated_client();
 
     let response = client.license().await;
 

--- a/tests/e2e/routes/about.rs
+++ b/tests/e2e/routes/about.rs
@@ -1,26 +1,24 @@
-use crate::e2e::asserts::{assert_ok, assert_response_title};
-use crate::e2e::client::Client;
-use crate::e2e::connection_info::connection_with_no_token;
-use crate::e2e::http::Query;
+use crate::e2e::asserts::{assert_response_title, assert_text_ok};
+use crate::e2e::env::TestEnv;
 
 #[tokio::test]
 #[cfg_attr(not(feature = "e2e-tests"), ignore)]
 async fn it_should_load_the_about_page_with_information_about_the_api() {
-    let client = Client::new(connection_with_no_token("localhost:3000"));
+    let client = TestEnv::default().guess_client();
 
-    let response = client.get("about", Query::empty()).await;
+    let response = client.about().await;
 
-    assert_ok(&response);
+    assert_text_ok(&response);
     assert_response_title(&response, "About");
 }
 
 #[tokio::test]
 #[cfg_attr(not(feature = "e2e-tests"), ignore)]
 async fn it_should_load_the_license_page_at_the_api_entrypoint() {
-    let client = Client::new(connection_with_no_token("localhost:3000"));
+    let client = TestEnv::default().guess_client();
 
-    let response = client.get("about/license", Query::empty()).await;
+    let response = client.license().await;
 
-    assert_ok(&response);
+    assert_text_ok(&response);
     assert_response_title(&response, "Licensing");
 }

--- a/tests/e2e/routes/category.rs
+++ b/tests/e2e/routes/category.rs
@@ -1,0 +1,21 @@
+use crate::e2e::asserts::assert_json_ok;
+use crate::e2e::env::TestEnv;
+use crate::e2e::http::Query;
+
+#[tokio::test]
+#[cfg_attr(not(feature = "e2e-tests"), ignore)]
+async fn it_should_return_an_empty_category_list_when_there_are_no_categories() {
+    let client = TestEnv::default().unauthenticated_client();
+
+    let response = client.get("category", Query::empty()).await;
+
+    assert_json_ok(&response);
+}
+
+/* todo:
+    - it_should_not_allow_adding_a_new_category_to_unauthenticated_clients
+    - it should allow adding a new category to authenticated clients
+    - it should not allow adding a new category with an empty name
+    - it should not allow adding a new category with an empty icon
+    - ...
+*/

--- a/tests/e2e/routes/mod.rs
+++ b/tests/e2e/routes/mod.rs
@@ -1,3 +1,3 @@
 pub mod about;
-
+pub mod category;
 pub mod root;

--- a/tests/e2e/routes/mod.rs
+++ b/tests/e2e/routes/mod.rs
@@ -1,2 +1,3 @@
 pub mod about;
+
 pub mod root;

--- a/tests/e2e/routes/root.rs
+++ b/tests/e2e/routes/root.rs
@@ -1,15 +1,13 @@
-use crate::e2e::asserts::{assert_ok, assert_response_title};
-use crate::e2e::client::Client;
-use crate::e2e::connection_info::connection_with_no_token;
-use crate::e2e::http::Query;
+use crate::e2e::asserts::{assert_response_title, assert_text_ok};
+use crate::e2e::env::TestEnv;
 
 #[tokio::test]
 #[cfg_attr(not(feature = "e2e-tests"), ignore)]
 async fn it_should_load_the_about_page_at_the_api_entrypoint() {
-    let client = Client::new(connection_with_no_token("localhost:3000"));
+    let client = TestEnv::default().guess_client();
 
-    let response = client.get("", Query::empty()).await;
+    let response = client.root().await;
 
-    assert_ok(&response);
+    assert_text_ok(&response);
     assert_response_title(&response, "About");
 }

--- a/tests/e2e/routes/root.rs
+++ b/tests/e2e/routes/root.rs
@@ -4,7 +4,7 @@ use crate::e2e::env::TestEnv;
 #[tokio::test]
 #[cfg_attr(not(feature = "e2e-tests"), ignore)]
 async fn it_should_load_the_about_page_at_the_api_entrypoint() {
-    let client = TestEnv::default().guess_client();
+    let client = TestEnv::default().unauthenticated_client();
 
     let response = client.root().await;
 


### PR DESCRIPTION
E2E tests for API `category` routes.