### PR TITLE
Add test for minimum page size for torrent list

### DIFF
--- a/src/databases/sqlite.rs
+++ b/src/databases/sqlite.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use chrono::NaiveDateTime;
+use log::debug;
 use sqlx::sqlite::SqlitePoolOptions;
 use sqlx::{query, query_as, Acquire, SqlitePool};
 
@@ -355,6 +356,8 @@ impl Database for SqliteDatabase {
         let count = count_result?;
 
         query_string = format!("{} ORDER BY {} LIMIT ?, ?", query_string, sort_query);
+
+        debug!("query bindings: title: {} offset: {} page_size: {}", title, offset, page_size);
 
         let res: Vec<TorrentListing> = sqlx::query_as::<_, TorrentListing>(&query_string)
             .bind(title)

--- a/src/routes/torrent.rs
+++ b/src/routes/torrent.rs
@@ -4,6 +4,7 @@ use actix_multipart::Multipart;
 use actix_web::web::Query;
 use actix_web::{web, HttpRequest, HttpResponse, Responder};
 use futures::{StreamExt, TryStreamExt};
+use log::debug;
 use serde::Deserialize;
 use sqlx::FromRow;
 
@@ -299,6 +300,8 @@ pub async fn delete_torrent(req: HttpRequest, app_data: WebAppData) -> ServiceRe
 
 // eg: /torrents?categories=music,other,movie&search=bunny&sort=size_DESC
 pub async fn get_torrents(params: Query<TorrentSearch>, app_data: WebAppData) -> ServiceResult<impl Responder> {
+    debug!("get_torrents: {:?}", params);
+
     let sort = params.sort.unwrap_or(Sorting::UploadedDesc);
 
     let page = params.page.unwrap_or(0);
@@ -315,7 +318,7 @@ pub async fn get_torrents(params: Query<TorrentSearch>, app_data: WebAppData) ->
 
     let torrents_response = app_data
         .database
-        .get_torrents_search_sorted_paginated(&params.search, &categories, &sort, offset, page_size as u8)
+        .get_torrents_search_sorted_paginated(&params.search, &categories, &sort, offset, page_size)
         .await?;
 
     Ok(HttpResponse::Ok().json(OkResponse { data: torrents_response }))

--- a/tests/e2e/client.rs
+++ b/tests/e2e/client.rs
@@ -72,8 +72,8 @@ impl Client {
 
     // Context: torrent
 
-    pub async fn get_torrents(&self) -> TextResponse {
-        self.http_client.get("torrents", Query::empty()).await
+    pub async fn get_torrents(&self, params: Query) -> TextResponse {
+        self.http_client.get("torrents", params).await
     }
 
     pub async fn get_torrent(&self, id: TorrentId) -> TextResponse {


### PR DESCRIPTION
The endpoint to get a torrent list allows pagination. But the min page size is set to 10 elements.