### PR TITLE
Fix deprecate chrono function warning

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -7,7 +7,7 @@ use crate::config::Configuration;
 use crate::databases::database::Database;
 use crate::errors::ServiceError;
 use crate::models::user::{UserClaims, UserCompact};
-use crate::utils::time::current_time;
+use crate::utils::clock::current_time;
 
 pub struct AuthorizationService {
     cfg: Arc<Configuration>,

--- a/src/databases/mysql.rs
+++ b/src/databases/mysql.rs
@@ -9,8 +9,8 @@ use crate::models::torrent::TorrentListing;
 use crate::models::torrent_file::{DbTorrentAnnounceUrl, DbTorrentFile, DbTorrentInfo, Torrent, TorrentFile};
 use crate::models::tracker_key::TrackerKey;
 use crate::models::user::{User, UserAuthentication, UserCompact, UserProfile};
+use crate::utils::clock::current_time;
 use crate::utils::hex::bytes_to_hex;
-use crate::utils::time::current_time;
 
 pub struct MysqlDatabase {
     pub pool: MySqlPool,

--- a/src/databases/sqlite.rs
+++ b/src/databases/sqlite.rs
@@ -9,8 +9,8 @@ use crate::models::torrent::TorrentListing;
 use crate::models::torrent_file::{DbTorrentAnnounceUrl, DbTorrentFile, DbTorrentInfo, Torrent, TorrentFile};
 use crate::models::tracker_key::TrackerKey;
 use crate::models::user::{User, UserAuthentication, UserCompact, UserProfile};
+use crate::utils::clock::current_time;
 use crate::utils::hex::bytes_to_hex;
-use crate::utils::time::current_time;
 
 pub struct SqliteDatabase {
     pub pool: SqlitePool,

--- a/src/mailer.rs
+++ b/src/mailer.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::Configuration;
 use crate::errors::ServiceError;
-use crate::utils::time::current_time;
+use crate::utils::clock::current_time;
 
 pub struct MailerService {
     cfg: Arc<Configuration>,

--- a/src/routes/user.rs
+++ b/src/routes/user.rs
@@ -13,8 +13,8 @@ use crate::errors::{ServiceError, ServiceResult};
 use crate::mailer::VerifyClaims;
 use crate::models::response::{OkResponse, TokenResponse};
 use crate::models::user::UserAuthentication;
+use crate::utils::clock::current_time;
 use crate::utils::regex::validate_email_address;
-use crate::utils::time::current_time;
 
 pub fn init_routes(cfg: &mut web::ServiceConfig) {
     cfg.service(

--- a/src/upgrades/from_v1_0_0_to_v2_0_0/databases/sqlite_v2_0_0.rs
+++ b/src/upgrades/from_v1_0_0_to_v2_0_0/databases/sqlite_v2_0_0.rs
@@ -46,11 +46,12 @@ impl TorrentRecordV2 {
     }
 }
 
+#[must_use]
 pub fn convert_timestamp_to_datetime(timestamp: i64) -> String {
     // The expected format in database is: 2022-11-04 09:53:57
     // MySQL uses a DATETIME column and SQLite uses a TEXT column.
 
-    let naive_datetime = NaiveDateTime::from_timestamp(timestamp, 0);
+    let naive_datetime = NaiveDateTime::from_timestamp_opt(timestamp, 0).expect("Overflow of i64 seconds, very future!");
     let datetime_again: DateTime<Utc> = DateTime::from_utc(naive_datetime, Utc);
 
     // Format without timezone

--- a/src/upgrades/from_v1_0_0_to_v2_0_0/databases/sqlite_v2_0_0.rs
+++ b/src/upgrades/from_v1_0_0_to_v2_0_0/databases/sqlite_v2_0_0.rs
@@ -29,6 +29,7 @@ pub struct TorrentRecordV2 {
 }
 
 impl TorrentRecordV2 {
+    #[must_use]
     pub fn from_v1_data(torrent: &TorrentRecordV1, torrent_info: &TorrentInfo, uploader: &UserRecordV1) -> Self {
         Self {
             torrent_id: torrent.torrent_id,
@@ -75,7 +76,7 @@ impl SqliteDatabaseV2_0_0 {
         sqlx::migrate!("migrations/sqlite3")
             .run(&self.pool)
             .await
-            .expect("Could not run database migrations.")
+            .expect("Could not run database migrations.");
     }
 
     pub async fn reset_categories_sequence(&self) -> Result<SqliteQueryResult, DatabaseError> {

--- a/src/utils/clock.rs
+++ b/src/utils/clock.rs
@@ -1,0 +1,4 @@
+#[must_use]
+pub fn current_time() -> u64 {
+    u64::try_from(chrono::prelude::Utc::now().timestamp()).expect("timestamp should be positive")
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,4 +1,4 @@
+pub mod clock;
 pub mod hex;
 pub mod parse_torrent;
 pub mod regex;
-pub mod time;

--- a/src/utils/time.rs
+++ b/src/utils/time.rs
@@ -1,3 +1,0 @@
-pub fn current_time() -> u64 {
-    chrono::prelude::Utc::now().timestamp() as u64
-}


### PR DESCRIPTION
It fixes this build warning:

```
warning: use of deprecated associated function `chrono::NaiveDateTime::from_timestamp`: use `from_timestamp_opt()` instead
  --> src/upgrades/from_v1_0_0_to_v2_0_0/databases/sqlite_v2_0_0.rs:53:41
   |
53 |     let naive_datetime = NaiveDateTime::from_timestamp(timestamp, 0);
   |                                         ^^^^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default
```