### PR TITLE
Add environment variable to change the default config file path `./config.toml`

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -6,7 +6,11 @@ use std::env;
 // Environment variables
 
 /// The whole `config.toml` file content. It has priority over the config file.
+/// Even if the file is not on the default path.
 pub const ENV_VAR_CONFIG: &str = "TORRUST_IDX_BACK_CONFIG";
+
+/// The `config.toml` file location.
+pub const ENV_VAR_CONFIG_PATH: &str = "TORRUST_IDX_BACK_CONFIG_PATH";
 
 // Default values
 
@@ -25,9 +29,11 @@ pub async fn init_configuration() -> Configuration {
 
         Configuration::load_from_env_var(ENV_VAR_CONFIG).unwrap()
     } else {
-        println!("Loading configuration from config file `{}`", ENV_VAR_DEFAULT_CONFIG_PATH);
+        let config_path = env::var(ENV_VAR_CONFIG_PATH).unwrap_or_else(|_| ENV_VAR_DEFAULT_CONFIG_PATH.to_string());
 
-        match Configuration::load_from_file(ENV_VAR_DEFAULT_CONFIG_PATH).await {
+        println!("Loading configuration from config file `{}`", config_path);
+
+        match Configuration::load_from_file(&config_path).await {
             Ok(config) => config,
             Err(error) => {
                 panic!("{}", error)

--- a/tests/e2e/contexts/settings/contract.rs
+++ b/tests/e2e/contexts/settings/contract.rs
@@ -67,14 +67,13 @@ async fn it_should_allow_admins_to_get_all_the_settings() {
 #[tokio::test]
 async fn it_should_allow_admins_to_update_all_the_settings() {
     let mut env = TestEnv::new();
+    env.start().await;
 
     if !env.is_isolated() {
         // This test can't be executed in a non-isolated environment because
         // it will change the settings for all the other tests.
         return;
     }
-
-    env.start().await;
 
     let logged_in_admin = new_logged_in_admin(&env).await;
     let client = Client::authenticated(&env.server_socket_addr().unwrap(), &logged_in_admin.token);

--- a/tests/environments/app_starter.rs
+++ b/tests/environments/app_starter.rs
@@ -8,6 +8,7 @@ use torrust_index_backend::config::{AppConfiguration, Configuration};
 /// It launches the app and provides a way to stop it.
 pub struct AppStarter {
     configuration: AppConfiguration,
+    config_path: Option<String>,
     /// The application binary state (started or not):
     ///  - `None`: if the app is not started,
     ///  - `RunningState`: if the app was started.
@@ -16,9 +17,10 @@ pub struct AppStarter {
 
 impl AppStarter {
     #[must_use]
-    pub fn with_custom_configuration(configuration: AppConfiguration) -> Self {
+    pub fn with_custom_configuration(configuration: AppConfiguration, config_path: Option<String>) -> Self {
         Self {
             configuration,
+            config_path,
             running_state: None,
         }
     }
@@ -29,6 +31,7 @@ impl AppStarter {
     pub async fn start(&mut self) {
         let configuration = Configuration {
             settings: RwLock::new(self.configuration.clone()),
+            config_path: self.config_path.clone(),
         };
 
         // Open a channel to communicate back with this function

--- a/tests/environments/isolated.rs
+++ b/tests/environments/isolated.rs
@@ -27,8 +27,12 @@ impl TestEnv {
         let temp_dir = TempDir::new().expect("failed to create a temporary directory");
 
         let configuration = ephemeral(&temp_dir);
+        // Even if we load the configuration from the environment variable, we
+        // still need to provide a path to save the configuration when the
+        // configuration is updated via the `POST /settings` endpoints.
+        let config_path = format!("{}/config.toml", temp_dir.path().to_string_lossy());
 
-        let app_starter = AppStarter::with_custom_configuration(configuration);
+        let app_starter = AppStarter::with_custom_configuration(configuration, Some(config_path));
 
         Self { app_starter, temp_dir }
     }


### PR DESCRIPTION
You can now overwrite the default config file path with:

```s
TORRUST_IDX_BACK_CONFIG_PATH=./storage/config/config.toml cargo run
```

The default path is `./config.toml`