### PR TITLE
Change GET torrents page size limits

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,8 +8,8 @@
 /bin/
 /config-idx-back.local.toml
 /config-tracker.local.toml
+/config.local.toml
 /config.toml
-/config.toml.local
 /cspell.json
 /data_v2.db*
 /data.db

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -2,7 +2,7 @@
 
 # Generate the default settings file if it does not exist
 if ! [ -f "./config.toml" ]; then
-    cp ./config.toml.local ./config.toml
+    cp ./config.local.toml ./config.toml
 fi
 
 # Generate storage directory if it does not exist

--- a/config-idx-back.local.toml
+++ b/config-idx-back.local.toml
@@ -37,3 +37,8 @@ capacity = 128000000
 entry_size_limit = 4000000
 user_quota_period_seconds = 3600
 user_quota_bytes = 64000000
+
+[api]
+default_torrent_page_size = 10
+max_torrent_page_size = 30
+

--- a/config.local.toml
+++ b/config.local.toml
@@ -36,3 +36,7 @@ capacity = 128000000
 entry_size_limit = 4000000
 user_quota_period_seconds = 3600
 user_quota_bytes = 64000000
+
+[api]
+default_torrent_page_size = 10
+max_torrent_page_size = 30

--- a/src/databases/mysql.rs
+++ b/src/databases/mysql.rs
@@ -290,7 +290,7 @@ impl Database for MysqlDatabase {
         categories: &Option<Vec<String>>,
         sort: &Sorting,
         offset: u64,
-        page_size: u8,
+        limit: u8,
     ) -> Result<TorrentsResponse, DatabaseError> {
         let title = match search {
             None => "%".to_string(),
@@ -365,7 +365,7 @@ impl Database for MysqlDatabase {
         let res: Vec<TorrentListing> = sqlx::query_as::<_, TorrentListing>(&query_string)
             .bind(title)
             .bind(offset as i64)
-            .bind(page_size)
+            .bind(limit)
             .fetch_all(&self.pool)
             .await
             .map_err(|_| DatabaseError::Error)?;

--- a/src/databases/sqlite.rs
+++ b/src/databases/sqlite.rs
@@ -285,7 +285,7 @@ impl Database for SqliteDatabase {
         categories: &Option<Vec<String>>,
         sort: &Sorting,
         offset: u64,
-        page_size: u8,
+        limit: u8,
     ) -> Result<TorrentsResponse, DatabaseError> {
         let title = match search {
             None => "%".to_string(),
@@ -360,7 +360,7 @@ impl Database for SqliteDatabase {
         let res: Vec<TorrentListing> = sqlx::query_as::<_, TorrentListing>(&query_string)
             .bind(title)
             .bind(offset as i64)
-            .bind(page_size)
+            .bind(limit)
             .fetch_all(&self.pool)
             .await
             .map_err(|_| DatabaseError::Error)?;

--- a/src/routes/settings.rs
+++ b/src/routes/settings.rs
@@ -2,7 +2,7 @@ use actix_web::{web, HttpRequest, HttpResponse, Responder};
 
 use crate::bootstrap::config::ENV_VAR_DEFAULT_CONFIG_PATH;
 use crate::common::WebAppData;
-use crate::config::TorrustConfig;
+use crate::config::AppConfiguration;
 use crate::errors::{ServiceError, ServiceResult};
 use crate::models::response::OkResponse;
 
@@ -28,7 +28,7 @@ pub async fn get_settings(req: HttpRequest, app_data: WebAppData) -> ServiceResu
         return Err(ServiceError::Unauthorized);
     }
 
-    let settings: tokio::sync::RwLockReadGuard<TorrustConfig> = app_data.cfg.settings.read().await;
+    let settings: tokio::sync::RwLockReadGuard<AppConfiguration> = app_data.cfg.settings.read().await;
 
     Ok(HttpResponse::Ok().json(OkResponse { data: &*settings }))
 }
@@ -49,7 +49,7 @@ pub async fn get_site_name(app_data: WebAppData) -> ServiceResult<impl Responder
 
 pub async fn update_settings(
     req: HttpRequest,
-    payload: web::Json<TorrustConfig>,
+    payload: web::Json<AppConfiguration>,
     app_data: WebAppData,
 ) -> ServiceResult<impl Responder> {
     // check for user

--- a/src/routes/torrent.rs
+++ b/src/routes/torrent.rs
@@ -29,7 +29,7 @@ pub fn init_routes(cfg: &mut web::ServiceConfig) {
                     .route(web::delete().to(delete_torrent_handler)),
             ),
     );
-    cfg.service(web::scope("/torrents").service(web::resource("").route(web::get().to(get_torrents))));
+    cfg.service(web::scope("/torrents").service(web::resource("").route(web::get().to(get_torrents_handler))));
 }
 
 #[derive(FromRow)]
@@ -321,28 +321,43 @@ pub async fn delete_torrent_handler(req: HttpRequest, app_data: WebAppData) -> S
     }))
 }
 
-// eg: /torrents?categories=music,other,movie&search=bunny&sort=size_DESC
-pub async fn get_torrents(params: Query<TorrentSearch>, app_data: WebAppData) -> ServiceResult<impl Responder> {
+/// It returns a list of torrents matching the search criteria.
+/// Eg: `/torrents?categories=music,other,movie&search=bunny&sort=size_DESC`
+///
+/// # Errors
+///
+/// Returns a `ServiceError::DatabaseError` if the database query fails.
+pub async fn get_torrents_handler(params: Query<TorrentSearch>, app_data: WebAppData) -> ServiceResult<impl Responder> {
     let sort = params.sort.unwrap_or(Sorting::UploadedDesc);
 
     let page = params.page.unwrap_or(0);
 
-    // make sure the min page size = 10
-    let page_size = match params.page_size.unwrap_or(30) {
-        0..=9 => 10,
-        v => v,
+    let page_size = params.page_size.unwrap_or(default_page_size());
+
+    let page_size = if page_size > max_torrent_page_size() {
+        max_torrent_page_size()
+    } else {
+        page_size
     };
 
-    let offset = (page * page_size as u32) as u64;
+    let offset = u64::from(page * u32::from(page_size));
 
     let categories = params.categories.as_csv::<String>().unwrap_or(None);
 
     let torrents_response = app_data
         .database
-        .get_torrents_search_sorted_paginated(&params.search, &categories, &sort, offset, page_size as u8)
+        .get_torrents_search_sorted_paginated(&params.search, &categories, &sort, offset, page_size)
         .await?;
 
     Ok(HttpResponse::Ok().json(OkResponse { data: torrents_response }))
+}
+
+fn max_torrent_page_size() -> u8 {
+    30
+}
+
+fn default_page_size() -> u8 {
+    10
 }
 
 fn get_torrent_infohash_from_request(req: &HttpRequest) -> Result<InfoHash, ServiceError> {

--- a/tests/common/client.rs
+++ b/tests/common/client.rs
@@ -89,8 +89,8 @@ impl Client {
 
     // Context: torrent
 
-    pub async fn get_torrents(&self) -> TextResponse {
-        self.http_client.get("torrents", Query::empty()).await
+    pub async fn get_torrents(&self, params: Query) -> TextResponse {
+        self.http_client.get("torrents", params).await
     }
 
     pub async fn get_torrent(&self, infohash: &InfoHash) -> TextResponse {

--- a/tests/common/contexts/settings/mod.rs
+++ b/tests/common/contexts/settings/mod.rs
@@ -3,8 +3,9 @@ pub mod responses;
 
 use serde::{Deserialize, Serialize};
 use torrust_index_backend::config::{
-    Auth as DomainAuth, Database as DomainDatabase, ImageCache as DomainImageCache, Mail as DomainMail, Network as DomainNetwork,
-    TorrustConfig as DomainSettings, Tracker as DomainTracker, Website as DomainWebsite,
+    Api as DomainApi, AppConfiguration as DomainSettings, Auth as DomainAuth, Database as DomainDatabase,
+    ImageCache as DomainImageCache, Mail as DomainMail, Network as DomainNetwork, Tracker as DomainTracker,
+    Website as DomainWebsite,
 };
 
 #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -16,6 +17,7 @@ pub struct Settings {
     pub database: Database,
     pub mail: Mail,
     pub image_cache: ImageCache,
+    pub api: Api,
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -72,6 +74,12 @@ pub struct ImageCache {
     pub user_quota_bytes: usize,
 }
 
+#[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
+pub struct Api {
+    pub default_torrent_page_size: u8,
+    pub max_torrent_page_size: u8,
+}
+
 impl From<DomainSettings> for Settings {
     fn from(settings: DomainSettings) -> Self {
         Settings {
@@ -82,19 +90,20 @@ impl From<DomainSettings> for Settings {
             database: Database::from(settings.database),
             mail: Mail::from(settings.mail),
             image_cache: ImageCache::from(settings.image_cache),
+            api: Api::from(settings.api),
         }
     }
 }
 
 impl From<DomainWebsite> for Website {
     fn from(website: DomainWebsite) -> Self {
-        Website { name: website.name }
+        Self { name: website.name }
     }
 }
 
 impl From<DomainTracker> for Tracker {
     fn from(tracker: DomainTracker) -> Self {
-        Tracker {
+        Self {
             url: tracker.url,
             mode: format!("{:?}", tracker.mode),
             api_url: tracker.api_url,
@@ -106,7 +115,7 @@ impl From<DomainTracker> for Tracker {
 
 impl From<DomainNetwork> for Network {
     fn from(net: DomainNetwork) -> Self {
-        Network {
+        Self {
             port: net.port,
             base_url: net.base_url,
         }
@@ -115,7 +124,7 @@ impl From<DomainNetwork> for Network {
 
 impl From<DomainAuth> for Auth {
     fn from(auth: DomainAuth) -> Self {
-        Auth {
+        Self {
             email_on_signup: format!("{:?}", auth.email_on_signup),
             min_password_length: auth.min_password_length,
             max_password_length: auth.max_password_length,
@@ -126,7 +135,7 @@ impl From<DomainAuth> for Auth {
 
 impl From<DomainDatabase> for Database {
     fn from(database: DomainDatabase) -> Self {
-        Database {
+        Self {
             connect_url: database.connect_url,
             torrent_info_update_interval: database.torrent_info_update_interval,
         }
@@ -135,7 +144,7 @@ impl From<DomainDatabase> for Database {
 
 impl From<DomainMail> for Mail {
     fn from(mail: DomainMail) -> Self {
-        Mail {
+        Self {
             email_verification_enabled: mail.email_verification_enabled,
             from: mail.from,
             reply_to: mail.reply_to,
@@ -149,12 +158,21 @@ impl From<DomainMail> for Mail {
 
 impl From<DomainImageCache> for ImageCache {
     fn from(image_cache: DomainImageCache) -> Self {
-        ImageCache {
+        Self {
             max_request_timeout_ms: image_cache.max_request_timeout_ms,
             capacity: image_cache.capacity,
             entry_size_limit: image_cache.entry_size_limit,
             user_quota_period_seconds: image_cache.user_quota_period_seconds,
             user_quota_bytes: image_cache.user_quota_bytes,
+        }
+    }
+}
+
+impl From<DomainApi> for Api {
+    fn from(api: DomainApi) -> Self {
+        Self {
+            default_torrent_page_size: api.default_torrent_page_size,
+            max_torrent_page_size: api.max_torrent_page_size,
         }
     }
 }

--- a/tests/environments/app_starter.rs
+++ b/tests/environments/app_starter.rs
@@ -3,11 +3,11 @@ use std::net::SocketAddr;
 use log::info;
 use tokio::sync::{oneshot, RwLock};
 use torrust_index_backend::app;
-use torrust_index_backend::config::{Configuration, TorrustConfig};
+use torrust_index_backend::config::{AppConfiguration, Configuration};
 
 /// It launches the app and provides a way to stop it.
 pub struct AppStarter {
-    configuration: TorrustConfig,
+    configuration: AppConfiguration,
     /// The application binary state (started or not):
     ///  - `None`: if the app is not started,
     ///  - `RunningState`: if the app was started.
@@ -16,7 +16,7 @@ pub struct AppStarter {
 
 impl AppStarter {
     #[must_use]
-    pub fn with_custom_configuration(configuration: TorrustConfig) -> Self {
+    pub fn with_custom_configuration(configuration: AppConfiguration) -> Self {
         Self {
             configuration,
             running_state: None,
@@ -72,7 +72,7 @@ impl AppStarter {
     }
 
     #[must_use]
-    pub fn server_configuration(&self) -> TorrustConfig {
+    pub fn server_configuration(&self) -> AppConfiguration {
         self.configuration.clone()
     }
 

--- a/tests/environments/isolated.rs
+++ b/tests/environments/isolated.rs
@@ -1,5 +1,5 @@
 use tempfile::TempDir;
-use torrust_index_backend::config::{TorrustConfig, FREE_PORT};
+use torrust_index_backend::config::{AppConfiguration, FREE_PORT};
 
 use super::app_starter::AppStarter;
 use crate::common::random;
@@ -40,7 +40,7 @@ impl TestEnv {
 
     /// Provides the whole server configuration.
     #[must_use]
-    pub fn server_configuration(&self) -> TorrustConfig {
+    pub fn server_configuration(&self) -> AppConfiguration {
         self.app_starter.server_configuration()
     }
 
@@ -63,8 +63,8 @@ impl Default for TestEnv {
 }
 
 /// Provides a configuration with ephemeral data for testing.
-fn ephemeral(temp_dir: &TempDir) -> TorrustConfig {
-    let mut configuration = TorrustConfig::default();
+fn ephemeral(temp_dir: &TempDir) -> AppConfiguration {
+    let mut configuration = AppConfiguration::default();
 
     // Ephemeral API port
     configuration.net.port = FREE_PORT;


### PR DESCRIPTION
Changes in GET torrents response pagination.

The minimum page size for GET torrents results was removed. You can request only one torrent.

**BREAKING CHANGE**: a maximum page size was added (30). If you request more than 30 torrents per page, the result will contain 30 torrents at the most.

- [x] Remove the minimum page size
- [x] Add a maximum page size
- [x] Add configuration options in `config.toml` for the default and maximum page size.