### PR TITLE
Move config option `torrent_info_update_interval`

### DIFF
--- a/config-idx-back.local.toml
+++ b/config-idx-back.local.toml
@@ -20,7 +20,6 @@ secret_key = "MaxVerstappenWC2021"
 [database]
 connect_url = "sqlite://storage/database/torrust_index_backend_e2e_testing.db?mode=rwc" # SQLite
 #connect_url = "mysql://root:root_secret_password@mysql:3306/torrust_index_backend" # MySQL
-torrent_info_update_interval = 3600
 
 [mail]
 email_verification_enabled = false
@@ -42,3 +41,5 @@ user_quota_bytes = 64000000
 default_torrent_page_size = 10
 max_torrent_page_size = 30
 
+[tracker_statistics_importer]
+torrent_info_update_interval = 3600

--- a/config.local.toml
+++ b/config.local.toml
@@ -19,7 +19,6 @@ secret_key = "MaxVerstappenWC2021"
 
 [database]
 connect_url = "sqlite://data.db?mode=rwc"
-torrent_info_update_interval = 3600
 
 [mail]
 email_verification_enabled = false
@@ -40,3 +39,6 @@ user_quota_bytes = 64000000
 [api]
 default_torrent_page_size = 10
 max_torrent_page_size = 30
+
+[tracker_statistics_importer]
+torrent_info_update_interval = 3600

--- a/src/app.rs
+++ b/src/app.rs
@@ -32,7 +32,7 @@ pub async fn run(configuration: Configuration) -> Running {
     let settings = cfg.settings.read().await;
 
     let database_connect_url = settings.database.connect_url.clone();
-    let database_torrent_info_update_interval = settings.database.torrent_info_update_interval;
+    let torrent_info_update_interval = settings.tracker_statistics_importer.torrent_info_update_interval;
     let net_port = settings.net.port;
 
     // IMPORTANT: drop settings before starting server to avoid read locks that
@@ -67,7 +67,7 @@ pub async fn run(configuration: Configuration) -> Running {
     let weak_tracker_statistics_importer = Arc::downgrade(&tracker_statistics_importer);
 
     let tracker_statistics_importer_handle = tokio::spawn(async move {
-        let interval = std::time::Duration::from_secs(database_torrent_info_update_interval);
+        let interval = std::time::Duration::from_secs(torrent_info_update_interval);
         let mut interval = tokio::time::interval(interval);
         interval.tick().await; // first tick is immediate...
         loop {

--- a/src/config.rs
+++ b/src/config.rs
@@ -108,14 +108,12 @@ impl Default for Auth {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Database {
     pub connect_url: String,
-    pub torrent_info_update_interval: u64,
 }
 
 impl Default for Database {
     fn default() -> Self {
         Self {
             connect_url: "sqlite://data.db?mode=rwc".to_string(),
-            torrent_info_update_interval: 3600,
         }
     }
 }
@@ -170,6 +168,19 @@ impl Default for Api {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrackerStatisticsImporter {
+    pub torrent_info_update_interval: u64,
+}
+
+impl Default for TrackerStatisticsImporter {
+    fn default() -> Self {
+        Self {
+            torrent_info_update_interval: 3600,
+        }
+    }
+}
+
 impl Default for ImageCache {
     fn default() -> Self {
         Self {
@@ -192,6 +203,7 @@ pub struct TorrustBackend {
     pub mail: Mail,
     pub image_cache: ImageCache,
     pub api: Api,
+    pub tracker_statistics_importer: TrackerStatisticsImporter,
 }
 
 #[derive(Debug)]

--- a/tests/common/contexts/settings/mod.rs
+++ b/tests/common/contexts/settings/mod.rs
@@ -4,7 +4,8 @@ pub mod responses;
 use serde::{Deserialize, Serialize};
 use torrust_index_backend::config::{
     Api as DomainApi, Auth as DomainAuth, Database as DomainDatabase, ImageCache as DomainImageCache, Mail as DomainMail,
-    Network as DomainNetwork, TorrustBackend as DomainSettings, Tracker as DomainTracker, Website as DomainWebsite,
+    Network as DomainNetwork, TorrustBackend as DomainSettings, Tracker as DomainTracker,
+    TrackerStatisticsImporter as DomainTrackerStatisticsImporter, Website as DomainWebsite,
 };
 
 #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -17,6 +18,7 @@ pub struct Settings {
     pub mail: Mail,
     pub image_cache: ImageCache,
     pub api: Api,
+    pub tracker_statistics_importer: TrackerStatisticsImporter,
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -50,7 +52,6 @@ pub struct Auth {
 #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
 pub struct Database {
     pub connect_url: String,
-    pub torrent_info_update_interval: u64,
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -79,6 +80,11 @@ pub struct Api {
     pub max_torrent_page_size: u8,
 }
 
+#[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
+pub struct TrackerStatisticsImporter {
+    pub torrent_info_update_interval: u64,
+}
+
 impl From<DomainSettings> for Settings {
     fn from(settings: DomainSettings) -> Self {
         Settings {
@@ -90,6 +96,7 @@ impl From<DomainSettings> for Settings {
             mail: Mail::from(settings.mail),
             image_cache: ImageCache::from(settings.image_cache),
             api: Api::from(settings.api),
+            tracker_statistics_importer: TrackerStatisticsImporter::from(settings.tracker_statistics_importer),
         }
     }
 }
@@ -136,7 +143,6 @@ impl From<DomainDatabase> for Database {
     fn from(database: DomainDatabase) -> Self {
         Self {
             connect_url: database.connect_url,
-            torrent_info_update_interval: database.torrent_info_update_interval,
         }
     }
 }
@@ -172,6 +178,14 @@ impl From<DomainApi> for Api {
         Self {
             default_torrent_page_size: api.default_torrent_page_size,
             max_torrent_page_size: api.max_torrent_page_size,
+        }
+    }
+}
+
+impl From<DomainTrackerStatisticsImporter> for TrackerStatisticsImporter {
+    fn from(tracker_statistics_importer: DomainTrackerStatisticsImporter) -> Self {
+        Self {
+            torrent_info_update_interval: tracker_statistics_importer.torrent_info_update_interval,
         }
     }
 }


### PR DESCRIPTION
From `database` section to a new section:

```toml
[tracker_statistics_importer]
torrent_info_update_interval = 3600
```

It's a breaking change.