### PR TITLE
ci: install `imdl` binary in all workflows

### DIFF
--- a/.github/workflows/publish_crate.yml
+++ b/.github/workflows/publish_crate.yml
@@ -29,6 +29,8 @@ jobs:
           toolchain: stable
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
+      - name: Install torrent edition tool (needed for testing)
+        run: cargo install imdl
       - name: Run Tests
         run: cargo test
 

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -35,6 +35,8 @@ jobs:
           toolchain: stable
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
+      - name: Install torrent edition tool (needed for testing)
+        run: cargo install imdl      
       - name: Run Tests
         run: cargo test
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
         run: sleep 15s
         shell: bash
       - uses: Swatinem/rust-cache@v1
+      - name: Install torrent edition tool (needed for testing)
+        run: cargo install imdl      
       - name: Run tests
         run: cargo test
       - name: Stop databases


### PR DESCRIPTION
Unit tests have a dependency with the binary: `imdl`. It's used to create and parse torrents.
Before running tests with `cargo test` you have to install with: `cargo install imdl`.