### PR TITLE
Add API version prefix in API URLs

### DIFF
--- a/src/routes/about.rs
+++ b/src/routes/about.rs
@@ -2,10 +2,11 @@ use actix_web::http::StatusCode;
 use actix_web::{web, HttpResponse, Responder};
 
 use crate::errors::ServiceResult;
+use crate::routes::API_VERSION;
 
 pub fn init(cfg: &mut web::ServiceConfig) {
     cfg.service(
-        web::scope("/about")
+        web::scope(&format!("/{API_VERSION}/about"))
             .service(web::resource("").route(web::get().to(get)))
             .service(web::resource("/license").route(web::get().to(license))),
     );

--- a/src/routes/category.rs
+++ b/src/routes/category.rs
@@ -4,10 +4,11 @@ use serde::{Deserialize, Serialize};
 use crate::common::WebAppData;
 use crate::errors::{ServiceError, ServiceResult};
 use crate::models::response::OkResponse;
+use crate::routes::API_VERSION;
 
 pub fn init(cfg: &mut web::ServiceConfig) {
     cfg.service(
-        web::scope("/category").service(
+        web::scope(&format!("/{API_VERSION}/category")).service(
             web::resource("")
                 .route(web::get().to(get))
                 .route(web::post().to(add))

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -8,6 +8,8 @@ pub mod settings;
 pub mod torrent;
 pub mod user;
 
+pub const API_VERSION: &str = "v1";
+
 pub fn init(cfg: &mut web::ServiceConfig) {
     user::init(cfg);
     torrent::init(cfg);

--- a/src/routes/proxy.rs
+++ b/src/routes/proxy.rs
@@ -8,6 +8,7 @@ use text_to_png::TextRenderer;
 use crate::cache::image::manager::Error;
 use crate::common::WebAppData;
 use crate::errors::ServiceResult;
+use crate::routes::API_VERSION;
 
 static ERROR_IMAGE_LOADER: Once = Once::new();
 
@@ -27,7 +28,9 @@ const ERROR_IMAGE_USER_QUOTA_MET_TEXT: &str = "Image proxy quota met.";
 const ERROR_IMAGE_UNAUTHENTICATED_TEXT: &str = "Sign in to see image.";
 
 pub fn init(cfg: &mut web::ServiceConfig) {
-    cfg.service(web::scope("/proxy").service(web::resource("/image/{url}").route(web::get().to(get_proxy_image))));
+    cfg.service(
+        web::scope(&format!("/{API_VERSION}/proxy")).service(web::resource("/image/{url}").route(web::get().to(get_proxy_image))),
+    );
 
     load_error_images();
 }

--- a/src/routes/root.rs
+++ b/src/routes/root.rs
@@ -1,7 +1,8 @@
 use actix_web::web;
 
-use crate::routes::about;
+use crate::routes::{about, API_VERSION};
 
 pub fn init(cfg: &mut web::ServiceConfig) {
     cfg.service(web::scope("/").service(web::resource("").route(web::get().to(about::get))));
+    cfg.service(web::scope(&format!("/{API_VERSION}")).service(web::resource("").route(web::get().to(about::get))));
 }

--- a/src/routes/settings.rs
+++ b/src/routes/settings.rs
@@ -4,10 +4,11 @@ use crate::common::WebAppData;
 use crate::config;
 use crate::errors::{ServiceError, ServiceResult};
 use crate::models::response::OkResponse;
+use crate::routes::API_VERSION;
 
 pub fn init(cfg: &mut web::ServiceConfig) {
     cfg.service(
-        web::scope("/settings")
+        web::scope(&format!("/{API_VERSION}/settings"))
             .service(web::resource("").route(web::get().to(get)).route(web::post().to(update)))
             .service(web::resource("/name").route(web::get().to(site_name)))
             .service(web::resource("/public").route(web::get().to(get_public))),

--- a/src/routes/torrent.rs
+++ b/src/routes/torrent.rs
@@ -14,12 +14,13 @@ use crate::errors::{ServiceError, ServiceResult};
 use crate::models::info_hash::InfoHash;
 use crate::models::response::{NewTorrentResponse, OkResponse, TorrentResponse};
 use crate::models::torrent::TorrentRequest;
+use crate::routes::API_VERSION;
 use crate::utils::parse_torrent;
 use crate::AsCSV;
 
 pub fn init(cfg: &mut web::ServiceConfig) {
     cfg.service(
-        web::scope("/torrent")
+        web::scope(&format!("/{API_VERSION}/torrent"))
             .service(web::resource("/upload").route(web::post().to(upload)))
             .service(web::resource("/download/{info_hash}").route(web::get().to(download_torrent_handler)))
             .service(
@@ -29,7 +30,9 @@ pub fn init(cfg: &mut web::ServiceConfig) {
                     .route(web::delete().to(delete)),
             ),
     );
-    cfg.service(web::scope("/torrents").service(web::resource("").route(web::get().to(get_torrents_handler))));
+    cfg.service(
+        web::scope(&format!("/{API_VERSION}/torrents")).service(web::resource("").route(web::get().to(get_torrents_handler))),
+    );
 }
 
 #[derive(FromRow)]

--- a/src/routes/user.rs
+++ b/src/routes/user.rs
@@ -13,12 +13,13 @@ use crate::errors::{ServiceError, ServiceResult};
 use crate::mailer::VerifyClaims;
 use crate::models::response::{OkResponse, TokenResponse};
 use crate::models::user::UserAuthentication;
+use crate::routes::API_VERSION;
 use crate::utils::clock;
 use crate::utils::regex::validate_email_address;
 
 pub fn init(cfg: &mut web::ServiceConfig) {
     cfg.service(
-        web::scope("/user")
+        web::scope(&format!("/{API_VERSION}/user"))
             .service(web::resource("/register").route(web::post().to(register)))
             .service(web::resource("/login").route(web::post().to(login)))
             // code-review: should not this be a POST method? We add the user to the blacklist. We do not delete the user.

--- a/tests/common/connection_info.rs
+++ b/tests/common/connection_info.rs
@@ -1,20 +1,23 @@
 #[derive(Clone)]
 pub struct ConnectionInfo {
     pub bind_address: String,
+    pub base_path: String,
     pub token: Option<String>,
 }
 
 impl ConnectionInfo {
-    pub fn new(bind_address: &str, token: &str) -> Self {
+    pub fn new(bind_address: &str, base_path: &str, token: &str) -> Self {
         Self {
             bind_address: bind_address.to_string(),
+            base_path: base_path.to_string(),
             token: Some(token.to_string()),
         }
     }
 
-    pub fn anonymous(bind_address: &str) -> Self {
+    pub fn anonymous(bind_address: &str, base_path: &str) -> Self {
         Self {
             bind_address: bind_address.to_string(),
+            base_path: base_path.to_string(),
             token: None,
         }
     }


### PR DESCRIPTION
BREAKING CHANGE: API urls have the prefix `/v1/...`