### PR TITLE
Axum API scaffolding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,6 +365,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "axum"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8175979259124331c1d7bf6586ee7e0da434155e4b2d48ec2c8386281d8df39"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1547,6 +1596,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
+name = "matchit"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2290,6 +2345,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+
+[[package]]
 name = "rustybuzz"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2465,6 +2526,15 @@ checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7f05c1d5476066defcdfacce1f52fc3cae3af1d3089727100c02ae92e5abbe0"
+dependencies = [
  "serde",
 ]
 
@@ -2779,6 +2849,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
 name = "tempfile"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3030,6 +3106,7 @@ dependencies = [
  "actix-web",
  "argon2",
  "async-trait",
+ "axum",
  "binascii",
  "bytes",
  "chrono",
@@ -3037,6 +3114,7 @@ dependencies = [
  "derive_more",
  "fern",
  "futures",
+ "hyper",
  "indexmap",
  "jsonwebtoken",
  "lettre",
@@ -3064,6 +3142,28 @@ dependencies = [
  "uuid",
  "which",
 ]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ text-to-png = "0.2"
 indexmap = "1.9"
 thiserror = "1.0"
 binascii = "0.1"
+axum = "0.6.18"
+hyper = "0.14.26"
 
 [dev-dependencies]
 rand = "0.8"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,11 +1,21 @@
 use torrust_index_backend::app;
 use torrust_index_backend::bootstrap::config::init_configuration;
+use torrust_index_backend::web::api::Implementation;
 
-#[actix_web::main]
+#[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     let configuration = init_configuration().await;
 
-    let app = app::run(configuration).await;
+    // todo: we are migrating from actix-web to axum, so we need to keep both
+    // implementations for a while. For production we only use ActixWeb.
+    // Once the Axum implementation is finished and stable, we can switch to it
+    // and remove the ActixWeb implementation.
+    let api_implementation = Implementation::ActixWeb;
 
-    app.api_server.await
+    let app = app::run(configuration, &api_implementation).await;
+
+    match api_implementation {
+        Implementation::ActixWeb => app.actix_web_api_server.unwrap().await.expect("the API server was dropped"),
+        Implementation::Axum => app.axum_api_server.unwrap().await.expect("the Axum API server was dropped"),
+    }
 }

--- a/src/bootstrap/logging.rs
+++ b/src/bootstrap/logging.rs
@@ -29,7 +29,7 @@ pub fn setup() {
 
 fn config_level_or_default(log_level: &Option<String>) -> LevelFilter {
     match log_level {
-        None => log::LevelFilter::Warn,
+        None => log::LevelFilter::Info,
         Some(level) => LevelFilter::from_str(level).unwrap(),
     }
 }

--- a/src/databases/mysql.rs
+++ b/src/databases/mysql.rs
@@ -1,7 +1,10 @@
+use std::str::FromStr;
+use std::time::Duration;
+
 use async_trait::async_trait;
 use chrono::NaiveDateTime;
-use sqlx::mysql::MySqlPoolOptions;
-use sqlx::{query, query_as, Acquire, MySqlPool};
+use sqlx::mysql::{MySqlConnectOptions, MySqlPoolOptions};
+use sqlx::{query, query_as, Acquire, ConnectOptions, MySqlPool};
 
 use crate::databases::database;
 use crate::databases::database::{Category, Database, Driver, Sorting, TorrentCompact};
@@ -25,8 +28,13 @@ impl Database for Mysql {
     }
 
     async fn new(database_url: &str) -> Self {
+        let mut connection_options = MySqlConnectOptions::from_str(database_url).expect("Unable to create connection options.");
+        connection_options
+            .log_statements(log::LevelFilter::Error)
+            .log_slow_statements(log::LevelFilter::Warn, Duration::from_secs(1));
+
         let db = MySqlPoolOptions::new()
-            .connect(database_url)
+            .connect_with(connection_options)
             .await
             .expect("Unable to create database pool.");
 

--- a/src/databases/sqlite.rs
+++ b/src/databases/sqlite.rs
@@ -1,7 +1,10 @@
+use std::str::FromStr;
+use std::time::Duration;
+
 use async_trait::async_trait;
 use chrono::NaiveDateTime;
-use sqlx::sqlite::SqlitePoolOptions;
-use sqlx::{query, query_as, Acquire, SqlitePool};
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use sqlx::{query, query_as, Acquire, ConnectOptions, SqlitePool};
 
 use crate::databases::database;
 use crate::databases::database::{Category, Database, Driver, Sorting, TorrentCompact};
@@ -25,8 +28,13 @@ impl Database for Sqlite {
     }
 
     async fn new(database_url: &str) -> Self {
+        let mut connection_options = SqliteConnectOptions::from_str(database_url).expect("Unable to create connection options.");
+        connection_options
+            .log_statements(log::LevelFilter::Error)
+            .log_slow_statements(log::LevelFilter::Warn, Duration::from_secs(1));
+
         let db = SqlitePoolOptions::new()
-            .connect(database_url)
+            .connect_with(connection_options)
             .await
             .expect("Unable to create database pool.");
 

--- a/src/services/about.rs
+++ b/src/services/about.rs
@@ -3,6 +3,11 @@ use crate::routes::API_VERSION;
 
 #[must_use]
 pub fn index_page() -> String {
+    page()
+}
+
+#[must_use]
+pub fn page() -> String {
     format!(
         r#"
     <html>

--- a/src/web/api/actix.rs
+++ b/src/web/api/actix.rs
@@ -1,0 +1,75 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use actix_cors::Cors;
+use actix_web::{middleware, web, App, HttpServer};
+use log::info;
+use tokio::sync::oneshot::{self, Sender};
+
+use super::Running;
+use crate::common::AppData;
+use crate::routes;
+use crate::web::api::ServerStartedMessage;
+
+/// Starts the API server with `ActixWeb`.
+///
+/// # Panics
+///
+/// Panics if the API server can't be started.
+pub async fn start(app_data: Arc<AppData>, net_ip: &str, net_port: u16) -> Running {
+    let config_socket_addr: SocketAddr = format!("{net_ip}:{net_port}")
+        .parse()
+        .expect("API server socket address to be valid.");
+
+    let (tx, rx) = oneshot::channel::<ServerStartedMessage>();
+
+    // Run the API server
+    let join_handle = tokio::spawn(async move {
+        info!("Starting API server with net config: {} ...", config_socket_addr);
+
+        let server_future = start_server(config_socket_addr, app_data.clone(), tx);
+
+        let _ = server_future.await;
+
+        Ok(())
+    });
+
+    // Wait until the API server is running
+    let bound_addr = match rx.await {
+        Ok(msg) => msg.socket_addr,
+        Err(e) => panic!("API server start. The API server was dropped: {e}"),
+    };
+
+    info!("API server started");
+
+    Running {
+        socket_addr: bound_addr,
+        actix_web_api_server: Some(join_handle),
+        axum_api_server: None,
+    }
+}
+
+fn start_server(
+    config_socket_addr: SocketAddr,
+    app_data: Arc<AppData>,
+    tx: Sender<ServerStartedMessage>,
+) -> actix_web::dev::Server {
+    let server = HttpServer::new(move || {
+        App::new()
+            .wrap(Cors::permissive())
+            .app_data(web::Data::new(app_data.clone()))
+            .wrap(middleware::Logger::default())
+            .configure(routes::init)
+    })
+    .bind(config_socket_addr)
+    .expect("can't bind server to socket address");
+
+    let bound_addr = server.addrs()[0];
+
+    info!("API server listening on http://{}", bound_addr);
+
+    tx.send(ServerStartedMessage { socket_addr: bound_addr })
+        .expect("the API server should not be dropped");
+
+    server.run()
+}

--- a/src/web/api/axum.rs
+++ b/src/web/api/axum.rs
@@ -1,0 +1,76 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use futures::Future;
+use log::info;
+use tokio::sync::oneshot::{self, Sender};
+
+use super::v1::routes::router;
+use super::{Running, ServerStartedMessage};
+use crate::common::AppData;
+
+/// Starts the API server with `Axum`.
+///
+/// # Panics
+///
+/// Panics if the API server can't be started.
+pub async fn start(app_data: Arc<AppData>, net_ip: &str, net_port: u16) -> Running {
+    let config_socket_addr: SocketAddr = format!("{net_ip}:{net_port}")
+        .parse()
+        .expect("API server socket address to be valid.");
+
+    let (tx, rx) = oneshot::channel::<ServerStartedMessage>();
+
+    // Run the API server
+    let join_handle = tokio::spawn(async move {
+        info!("Starting API server with net config: {} ...", config_socket_addr);
+
+        let handle = start_server(config_socket_addr, app_data.clone(), tx);
+
+        if let Ok(()) = handle.await {
+            info!("API server stopped");
+        }
+
+        Ok(())
+    });
+
+    // Wait until the API server is running
+    let bound_addr = match rx.await {
+        Ok(msg) => msg.socket_addr,
+        Err(e) => panic!("API server start. The API server was dropped: {e}"),
+    };
+
+    Running {
+        socket_addr: bound_addr,
+        actix_web_api_server: None,
+        axum_api_server: Some(join_handle),
+    }
+}
+
+fn start_server(
+    config_socket_addr: SocketAddr,
+    app_data: Arc<AppData>,
+    tx: Sender<ServerStartedMessage>,
+) -> impl Future<Output = hyper::Result<()>> {
+    let tcp_listener = std::net::TcpListener::bind(config_socket_addr).expect("tcp listener to bind to a socket address");
+
+    let bound_addr = tcp_listener
+        .local_addr()
+        .expect("tcp listener to be bound to a socket address.");
+
+    info!("API server listening on http://{}", bound_addr);
+
+    let app = router(app_data);
+
+    let server = axum::Server::from_tcp(tcp_listener)
+        .expect("a new server from the previously created tcp listener.")
+        .serve(app.into_make_service_with_connect_info::<SocketAddr>());
+
+    tx.send(ServerStartedMessage { socket_addr: bound_addr })
+        .expect("the API server should not be dropped");
+
+    server.with_graceful_shutdown(async move {
+        tokio::signal::ctrl_c().await.expect("Failed to listen to shutdown signal.");
+        info!("Stopping API server on http://{} ...", bound_addr);
+    })
+}

--- a/src/web/api/mod.rs
+++ b/src/web/api/mod.rs
@@ -3,4 +3,51 @@
 //! Currently, the API has only one version: `v1`.
 //!
 //! Refer to the [`v1`](crate::web::api::v1) module for more information.
+pub mod actix;
+pub mod axum;
 pub mod v1;
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use tokio::task::JoinHandle;
+
+use crate::common::AppData;
+use crate::web::api;
+
+/// API implementations.
+pub enum Implementation {
+    /// API implementation with Actix Web.
+    ActixWeb,
+    /// API implementation with Axum.
+    Axum,
+}
+
+/// The running API server.
+pub struct Running {
+    /// The socket address the API server is listening on.
+    pub socket_addr: SocketAddr,
+    /// The API server when using Actix Web.
+    pub actix_web_api_server: Option<JoinHandle<Result<(), std::io::Error>>>,
+    /// The handle for the running API server task when using Axum.
+    pub axum_api_server: Option<JoinHandle<Result<(), std::io::Error>>>,
+}
+
+#[must_use]
+#[derive(Debug)]
+pub struct ServerStartedMessage {
+    pub socket_addr: SocketAddr,
+}
+
+/// Starts the API server.
+///
+/// We are migrating the API server from Actix Web to Axum. While the migration
+/// is in progress, we will keep both implementations, running the Axum one only
+/// for testing purposes.
+#[must_use]
+pub async fn start(app_data: Arc<AppData>, net_ip: &str, net_port: u16, implementation: &Implementation) -> api::Running {
+    match implementation {
+        Implementation::ActixWeb => actix::start(app_data, net_ip, net_port).await,
+        Implementation::Axum => axum::start(app_data, net_ip, net_port).await,
+    }
+}

--- a/src/web/api/v1/contexts/about/handlers.rs
+++ b/src/web/api/v1/contexts/about/handlers.rs
@@ -1,0 +1,20 @@
+//! API handlers for the the [`about`](crate::web::api::v1::contexts::about) API
+//! context.
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::{header, StatusCode};
+use axum::response::{IntoResponse, Response};
+
+use crate::common::AppData;
+use crate::services::about;
+
+#[allow(clippy::unused_async)]
+pub async fn about_page_handler(State(_app_data): State<Arc<AppData>>) -> Response {
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "text/html; charset=utf-8")],
+        about::page(),
+    )
+        .into_response()
+}

--- a/src/web/api/v1/contexts/about/mod.rs
+++ b/src/web/api/v1/contexts/about/mod.rs
@@ -84,3 +84,5 @@
 //!     </footer>
 //! </html>
 //! ```
+pub mod handlers;
+pub mod routes;

--- a/src/web/api/v1/contexts/about/routes.rs
+++ b/src/web/api/v1/contexts/about/routes.rs
@@ -1,0 +1,15 @@
+//! API routes for the [`about`](crate::web::api::v1::contexts::about) API context.
+//!
+//! Refer to the [API endpoint documentation](crate::web::api::v1::contexts::about).
+use std::sync::Arc;
+
+use axum::routing::get;
+use axum::Router;
+
+use super::handlers::about_page_handler;
+use crate::common::AppData;
+
+/// It adds the routes to the router for the [`about`](crate::web::api::v1::contexts::about) API context.
+pub fn add(prefix: &str, router: Router, app_data: Arc<AppData>) -> Router {
+    router.route(&format!("{prefix}/about"), get(about_page_handler).with_state(app_data))
+}

--- a/src/web/api/v1/mod.rs
+++ b/src/web/api/v1/mod.rs
@@ -6,3 +6,4 @@
 //! information.
 pub mod auth;
 pub mod contexts;
+pub mod routes;

--- a/src/web/api/v1/routes.rs
+++ b/src/web/api/v1/routes.rs
@@ -1,0 +1,22 @@
+//! Route initialization for the v1 API.
+use std::sync::Arc;
+
+use axum::Router;
+
+use super::contexts::about;
+use crate::common::AppData;
+
+/// Add all API routes to the router.
+#[allow(clippy::needless_pass_by_value)]
+pub fn router(app_data: Arc<AppData>) -> Router {
+    let router = Router::new();
+
+    add(router, app_data)
+}
+
+/// Add the routes for the v1 API.
+fn add(router: Router, app_data: Arc<AppData>) -> Router {
+    let v1_prefix = "/v1".to_string();
+
+    about::routes::add(&v1_prefix, router, app_data)
+}

--- a/tests/e2e/contexts/about/contract.rs
+++ b/tests/e2e/contexts/about/contract.rs
@@ -1,4 +1,6 @@
 //! API contract for `about` context.
+use torrust_index_backend::web::api;
+
 use crate::common::asserts::{assert_response_title, assert_text_ok};
 use crate::common::client::Client;
 use crate::e2e::environment::TestEnv;
@@ -6,7 +8,7 @@ use crate::e2e::environment::TestEnv;
 #[tokio::test]
 async fn it_should_load_the_about_page_with_information_about_the_api() {
     let mut env = TestEnv::new();
-    env.start().await;
+    env.start(api::Implementation::ActixWeb).await;
     let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
     let response = client.about().await;
@@ -18,11 +20,31 @@ async fn it_should_load_the_about_page_with_information_about_the_api() {
 #[tokio::test]
 async fn it_should_load_the_license_page_at_the_api_entrypoint() {
     let mut env = TestEnv::new();
-    env.start().await;
+    env.start(api::Implementation::ActixWeb).await;
     let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
     let response = client.license().await;
 
     assert_text_ok(&response);
     assert_response_title(&response, "Licensing");
+}
+
+mod with_axum_implementation {
+    use torrust_index_backend::web::api;
+
+    use crate::common::asserts::{assert_response_title, assert_text_ok};
+    use crate::common::client::Client;
+    use crate::e2e::environment::TestEnv;
+
+    #[tokio::test]
+    async fn it_should_load_the_about_page_with_information_about_the_api() {
+        let mut env = TestEnv::new();
+        env.start(api::Implementation::Axum).await;
+        let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
+
+        let response = client.about().await;
+
+        assert_text_ok(&response);
+        assert_response_title(&response, "About");
+    }
 }

--- a/tests/e2e/contexts/category/contract.rs
+++ b/tests/e2e/contexts/category/contract.rs
@@ -1,4 +1,6 @@
 //! API contract for `category` context.
+use torrust_index_backend::web::api;
+
 use crate::common::asserts::assert_json_ok;
 use crate::common::client::Client;
 use crate::common::contexts::category::fixtures::random_category_name;
@@ -18,7 +20,7 @@ use crate::e2e::environment::TestEnv;
 #[tokio::test]
 async fn it_should_return_an_empty_category_list_when_there_are_no_categories() {
     let mut env = TestEnv::new();
-    env.start().await;
+    env.start(api::Implementation::ActixWeb).await;
     let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
     let response = client.get_categories().await;
@@ -29,7 +31,7 @@ async fn it_should_return_an_empty_category_list_when_there_are_no_categories() 
 #[tokio::test]
 async fn it_should_return_a_category_list() {
     let mut env = TestEnv::new();
-    env.start().await;
+    env.start(api::Implementation::ActixWeb).await;
     let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
     // Add a category
@@ -53,7 +55,7 @@ async fn it_should_return_a_category_list() {
 #[tokio::test]
 async fn it_should_not_allow_adding_a_new_category_to_unauthenticated_users() {
     let mut env = TestEnv::new();
-    env.start().await;
+    env.start(api::Implementation::ActixWeb).await;
     let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
     let response = client
@@ -69,7 +71,7 @@ async fn it_should_not_allow_adding_a_new_category_to_unauthenticated_users() {
 #[tokio::test]
 async fn it_should_not_allow_adding_a_new_category_to_non_admins() {
     let mut env = TestEnv::new();
-    env.start().await;
+    env.start(api::Implementation::ActixWeb).await;
 
     let logged_non_admin = new_logged_in_user(&env).await;
 
@@ -88,7 +90,7 @@ async fn it_should_not_allow_adding_a_new_category_to_non_admins() {
 #[tokio::test]
 async fn it_should_allow_admins_to_add_new_categories() {
     let mut env = TestEnv::new();
-    env.start().await;
+    env.start(api::Implementation::ActixWeb).await;
 
     let logged_in_admin = new_logged_in_admin(&env).await;
     let client = Client::authenticated(&env.server_socket_addr().unwrap(), &logged_in_admin.token);
@@ -114,7 +116,7 @@ async fn it_should_allow_admins_to_add_new_categories() {
 #[tokio::test]
 async fn it_should_not_allow_adding_duplicated_categories() {
     let mut env = TestEnv::new();
-    env.start().await;
+    env.start(api::Implementation::ActixWeb).await;
 
     // Add a category
     let random_category_name = random_category_name();
@@ -129,7 +131,7 @@ async fn it_should_not_allow_adding_duplicated_categories() {
 #[tokio::test]
 async fn it_should_allow_admins_to_delete_categories() {
     let mut env = TestEnv::new();
-    env.start().await;
+    env.start(api::Implementation::ActixWeb).await;
 
     let logged_in_admin = new_logged_in_admin(&env).await;
     let client = Client::authenticated(&env.server_socket_addr().unwrap(), &logged_in_admin.token);
@@ -158,7 +160,7 @@ async fn it_should_allow_admins_to_delete_categories() {
 #[tokio::test]
 async fn it_should_not_allow_non_admins_to_delete_categories() {
     let mut env = TestEnv::new();
-    env.start().await;
+    env.start(api::Implementation::ActixWeb).await;
 
     // Add a category
     let category_name = random_category_name();
@@ -181,7 +183,7 @@ async fn it_should_not_allow_non_admins_to_delete_categories() {
 #[tokio::test]
 async fn it_should_not_allow_guests_to_delete_categories() {
     let mut env = TestEnv::new();
-    env.start().await;
+    env.start(api::Implementation::ActixWeb).await;
     let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
     // Add a category

--- a/tests/e2e/contexts/root/contract.rs
+++ b/tests/e2e/contexts/root/contract.rs
@@ -1,4 +1,6 @@
 //! API contract for `root` context.
+use torrust_index_backend::web::api;
+
 use crate::common::asserts::{assert_response_title, assert_text_ok};
 use crate::common::client::Client;
 use crate::e2e::environment::TestEnv;
@@ -6,7 +8,7 @@ use crate::e2e::environment::TestEnv;
 #[tokio::test]
 async fn it_should_load_the_about_page_at_the_api_entrypoint() {
     let mut env = TestEnv::new();
-    env.start().await;
+    env.start(api::Implementation::ActixWeb).await;
     let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
     let response = client.root().await;

--- a/tests/e2e/contexts/settings/contract.rs
+++ b/tests/e2e/contexts/settings/contract.rs
@@ -1,3 +1,5 @@
+use torrust_index_backend::web::api;
+
 use crate::common::client::Client;
 use crate::common::contexts::settings::responses::{AllSettingsResponse, Public, PublicSettingsResponse, SiteNameResponse};
 use crate::e2e::contexts::user::steps::new_logged_in_admin;
@@ -6,7 +8,7 @@ use crate::e2e::environment::TestEnv;
 #[tokio::test]
 async fn it_should_allow_guests_to_get_the_public_settings() {
     let mut env = TestEnv::new();
-    env.start().await;
+    env.start(api::Implementation::ActixWeb).await;
     let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
     let response = client.get_public_settings().await;
@@ -31,7 +33,7 @@ async fn it_should_allow_guests_to_get_the_public_settings() {
 #[tokio::test]
 async fn it_should_allow_guests_to_get_the_site_name() {
     let mut env = TestEnv::new();
-    env.start().await;
+    env.start(api::Implementation::ActixWeb).await;
     let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
     let response = client.get_site_name().await;
@@ -48,7 +50,7 @@ async fn it_should_allow_guests_to_get_the_site_name() {
 #[tokio::test]
 async fn it_should_allow_admins_to_get_all_the_settings() {
     let mut env = TestEnv::new();
-    env.start().await;
+    env.start(api::Implementation::ActixWeb).await;
 
     let logged_in_admin = new_logged_in_admin(&env).await;
     let client = Client::authenticated(&env.server_socket_addr().unwrap(), &logged_in_admin.token);
@@ -67,7 +69,7 @@ async fn it_should_allow_admins_to_get_all_the_settings() {
 #[tokio::test]
 async fn it_should_allow_admins_to_update_all_the_settings() {
     let mut env = TestEnv::new();
-    env.start().await;
+    env.start(api::Implementation::ActixWeb).await;
 
     if !env.is_isolated() {
         // This test can't be executed in a non-isolated environment because

--- a/tests/e2e/contexts/torrent/contract.rs
+++ b/tests/e2e/contexts/torrent/contract.rs
@@ -16,6 +16,7 @@ Get torrent info:
 
 mod for_guests {
     use torrust_index_backend::utils::parse_torrent::decode_torrent;
+    use torrust_index_backend::web::api;
 
     use crate::common::client::Client;
     use crate::common::contexts::category::fixtures::software_predefined_category_id;
@@ -33,7 +34,7 @@ mod for_guests {
     #[tokio::test]
     async fn it_should_allow_guests_to_get_torrents() {
         let mut env = TestEnv::new();
-        env.start().await;
+        env.start(api::Implementation::ActixWeb).await;
 
         if !env.provides_a_tracker() {
             println!("test skipped. It requires a tracker to be running.");
@@ -56,7 +57,7 @@ mod for_guests {
     #[tokio::test]
     async fn it_should_allow_to_get_torrents_with_pagination() {
         let mut env = TestEnv::new();
-        env.start().await;
+        env.start(api::Implementation::ActixWeb).await;
 
         if !env.provides_a_tracker() {
             println!("test skipped. It requires a tracker to be running.");
@@ -86,7 +87,7 @@ mod for_guests {
     #[tokio::test]
     async fn it_should_allow_to_limit_the_number_of_torrents_per_request() {
         let mut env = TestEnv::new();
-        env.start().await;
+        env.start(api::Implementation::ActixWeb).await;
 
         if !env.provides_a_tracker() {
             println!("test skipped. It requires a tracker to be running.");
@@ -121,7 +122,7 @@ mod for_guests {
     #[tokio::test]
     async fn it_should_return_a_default_amount_of_torrents_per_request_if_no_page_size_is_provided() {
         let mut env = TestEnv::new();
-        env.start().await;
+        env.start(api::Implementation::ActixWeb).await;
 
         if !env.provides_a_tracker() {
             println!("test skipped. It requires a tracker to be running.");
@@ -152,7 +153,7 @@ mod for_guests {
     #[tokio::test]
     async fn it_should_allow_guests_to_get_torrent_details_searching_by_info_hash() {
         let mut env = TestEnv::new();
-        env.start().await;
+        env.start(api::Implementation::ActixWeb).await;
 
         if !env.provides_a_tracker() {
             println!("test skipped. It requires a tracker to be running.");
@@ -215,7 +216,7 @@ mod for_guests {
     #[tokio::test]
     async fn it_should_allow_guests_to_download_a_torrent_file_searching_by_info_hash() {
         let mut env = TestEnv::new();
-        env.start().await;
+        env.start(api::Implementation::ActixWeb).await;
 
         if !env.provides_a_tracker() {
             println!("test skipped. It requires a tracker to be running.");
@@ -240,7 +241,7 @@ mod for_guests {
     #[tokio::test]
     async fn it_should_return_a_not_found_trying_to_download_a_non_existing_torrent() {
         let mut env = TestEnv::new();
-        env.start().await;
+        env.start(api::Implementation::ActixWeb).await;
 
         if !env.provides_a_tracker() {
             println!("test skipped. It requires a tracker to be running.");
@@ -260,7 +261,7 @@ mod for_guests {
     #[tokio::test]
     async fn it_should_not_allow_guests_to_delete_torrents() {
         let mut env = TestEnv::new();
-        env.start().await;
+        env.start(api::Implementation::ActixWeb).await;
 
         if !env.provides_a_tracker() {
             println!("test skipped. It requires a tracker to be running.");
@@ -281,6 +282,7 @@ mod for_guests {
 mod for_authenticated_users {
 
     use torrust_index_backend::utils::parse_torrent::decode_torrent;
+    use torrust_index_backend::web::api;
 
     use crate::common::client::Client;
     use crate::common::contexts::torrent::fixtures::random_torrent;
@@ -294,7 +296,7 @@ mod for_authenticated_users {
     #[tokio::test]
     async fn it_should_allow_authenticated_users_to_upload_new_torrents() {
         let mut env = TestEnv::new();
-        env.start().await;
+        env.start(api::Implementation::ActixWeb).await;
 
         if !env.provides_a_tracker() {
             println!("test skipped. It requires a tracker to be running.");
@@ -323,7 +325,7 @@ mod for_authenticated_users {
     #[tokio::test]
     async fn it_should_not_allow_uploading_a_torrent_with_a_non_existing_category() {
         let mut env = TestEnv::new();
-        env.start().await;
+        env.start(api::Implementation::ActixWeb).await;
 
         let uploader = new_logged_in_user(&env).await;
         let client = Client::authenticated(&env.server_socket_addr().unwrap(), &uploader.token);
@@ -342,7 +344,7 @@ mod for_authenticated_users {
     #[tokio::test]
     async fn it_should_not_allow_uploading_a_torrent_with_a_title_that_already_exists() {
         let mut env = TestEnv::new();
-        env.start().await;
+        env.start(api::Implementation::ActixWeb).await;
 
         if !env.provides_a_tracker() {
             println!("test skipped. It requires a tracker to be running.");
@@ -371,7 +373,7 @@ mod for_authenticated_users {
     #[tokio::test]
     async fn it_should_not_allow_uploading_a_torrent_with_a_info_hash_that_already_exists() {
         let mut env = TestEnv::new();
-        env.start().await;
+        env.start(api::Implementation::ActixWeb).await;
 
         if !env.provides_a_tracker() {
             println!("test skipped. It requires a tracker to be running.");
@@ -401,7 +403,7 @@ mod for_authenticated_users {
     #[tokio::test]
     async fn it_should_allow_authenticated_users_to_download_a_torrent_with_a_personal_announce_url() {
         let mut env = TestEnv::new();
-        env.start().await;
+        env.start(api::Implementation::ActixWeb).await;
 
         if !env.provides_a_tracker() {
             println!("test skipped. It requires a tracker to be running.");
@@ -435,6 +437,8 @@ mod for_authenticated_users {
     }
 
     mod and_non_admins {
+        use torrust_index_backend::web::api;
+
         use crate::common::client::Client;
         use crate::common::contexts::torrent::forms::UpdateTorrentFrom;
         use crate::e2e::contexts::torrent::steps::upload_random_torrent_to_index;
@@ -444,7 +448,7 @@ mod for_authenticated_users {
         #[tokio::test]
         async fn it_should_not_allow_non_admins_to_delete_torrents() {
             let mut env = TestEnv::new();
-            env.start().await;
+            env.start(api::Implementation::ActixWeb).await;
 
             if !env.provides_a_tracker() {
                 println!("test skipped. It requires a tracker to be running.");
@@ -464,7 +468,7 @@ mod for_authenticated_users {
         #[tokio::test]
         async fn it_should_allow_non_admin_users_to_update_someone_elses_torrents() {
             let mut env = TestEnv::new();
-            env.start().await;
+            env.start(api::Implementation::ActixWeb).await;
 
             if !env.provides_a_tracker() {
                 println!("test skipped. It requires a tracker to be running.");
@@ -497,6 +501,8 @@ mod for_authenticated_users {
     }
 
     mod and_torrent_owners {
+        use torrust_index_backend::web::api;
+
         use crate::common::client::Client;
         use crate::common::contexts::torrent::forms::UpdateTorrentFrom;
         use crate::common::contexts::torrent::responses::UpdatedTorrentResponse;
@@ -507,7 +513,7 @@ mod for_authenticated_users {
         #[tokio::test]
         async fn it_should_allow_torrent_owners_to_update_their_torrents() {
             let mut env = TestEnv::new();
-            env.start().await;
+            env.start(api::Implementation::ActixWeb).await;
 
             if !env.provides_a_tracker() {
                 println!("test skipped. It requires a tracker to be running.");
@@ -543,6 +549,8 @@ mod for_authenticated_users {
     }
 
     mod and_admins {
+        use torrust_index_backend::web::api;
+
         use crate::common::client::Client;
         use crate::common::contexts::torrent::forms::UpdateTorrentFrom;
         use crate::common::contexts::torrent::responses::{DeletedTorrentResponse, UpdatedTorrentResponse};
@@ -553,7 +561,7 @@ mod for_authenticated_users {
         #[tokio::test]
         async fn it_should_allow_admins_to_delete_torrents_searching_by_info_hash() {
             let mut env = TestEnv::new();
-            env.start().await;
+            env.start(api::Implementation::ActixWeb).await;
 
             if !env.provides_a_tracker() {
                 println!("test skipped. It requires a tracker to be running.");
@@ -577,7 +585,7 @@ mod for_authenticated_users {
         #[tokio::test]
         async fn it_should_allow_admins_to_update_someone_elses_torrents() {
             let mut env = TestEnv::new();
-            env.start().await;
+            env.start(api::Implementation::ActixWeb).await;
 
             if !env.provides_a_tracker() {
                 println!("test skipped. It requires a tracker to be running.");

--- a/tests/e2e/contexts/user/contract.rs
+++ b/tests/e2e/contexts/user/contract.rs
@@ -1,4 +1,6 @@
 //! API contract for `user` context.
+use torrust_index_backend::web::api;
+
 use crate::common::client::Client;
 use crate::common::contexts::user::fixtures::random_user_registration;
 use crate::common::contexts::user::forms::{LoginForm, TokenRenewalForm, TokenVerificationForm};
@@ -39,7 +41,7 @@ the mailcatcher API.
 #[tokio::test]
 async fn it_should_allow_a_guest_user_to_register() {
     let mut env = TestEnv::new();
-    env.start().await;
+    env.start(api::Implementation::ActixWeb).await;
     let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
     let form = random_user_registration();
@@ -56,7 +58,7 @@ async fn it_should_allow_a_guest_user_to_register() {
 #[tokio::test]
 async fn it_should_allow_a_registered_user_to_login() {
     let mut env = TestEnv::new();
-    env.start().await;
+    env.start(api::Implementation::ActixWeb).await;
     let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
     let registered_user = new_registered_user(&env).await;
@@ -81,7 +83,7 @@ async fn it_should_allow_a_registered_user_to_login() {
 #[tokio::test]
 async fn it_should_allow_a_logged_in_user_to_verify_an_authentication_token() {
     let mut env = TestEnv::new();
-    env.start().await;
+    env.start(api::Implementation::ActixWeb).await;
     let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
     let logged_in_user = new_logged_in_user(&env).await;
@@ -104,7 +106,7 @@ async fn it_should_allow_a_logged_in_user_to_verify_an_authentication_token() {
 #[tokio::test]
 async fn it_should_not_allow_a_logged_in_user_to_renew_an_authentication_token_which_is_still_valid_for_more_than_one_week() {
     let mut env = TestEnv::new();
-    env.start().await;
+    env.start(api::Implementation::ActixWeb).await;
 
     let logged_in_user = new_logged_in_user(&env).await;
     let client = Client::authenticated(&env.server_socket_addr().unwrap(), &logged_in_user.token);
@@ -132,6 +134,8 @@ async fn it_should_not_allow_a_logged_in_user_to_renew_an_authentication_token_w
 }
 
 mod banned_user_list {
+    use torrust_index_backend::web::api;
+
     use crate::common::client::Client;
     use crate::common::contexts::user::forms::Username;
     use crate::common::contexts::user::responses::BannedUserResponse;
@@ -141,7 +145,7 @@ mod banned_user_list {
     #[tokio::test]
     async fn it_should_allow_an_admin_to_ban_a_user() {
         let mut env = TestEnv::new();
-        env.start().await;
+        env.start(api::Implementation::ActixWeb).await;
 
         let logged_in_admin = new_logged_in_admin(&env).await;
         let client = Client::authenticated(&env.server_socket_addr().unwrap(), &logged_in_admin.token);
@@ -162,7 +166,7 @@ mod banned_user_list {
     #[tokio::test]
     async fn it_should_not_allow_a_non_admin_to_ban_a_user() {
         let mut env = TestEnv::new();
-        env.start().await;
+        env.start(api::Implementation::ActixWeb).await;
 
         let logged_non_admin = new_logged_in_user(&env).await;
         let client = Client::authenticated(&env.server_socket_addr().unwrap(), &logged_non_admin.token);
@@ -177,7 +181,7 @@ mod banned_user_list {
     #[tokio::test]
     async fn it_should_not_allow_a_guest_to_ban_a_user() {
         let mut env = TestEnv::new();
-        env.start().await;
+        env.start(api::Implementation::ActixWeb).await;
         let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
         let registered_user = new_registered_user(&env).await;

--- a/tests/e2e/environment.rs
+++ b/tests/e2e/environment.rs
@@ -1,5 +1,7 @@
 use std::env;
 
+use torrust_index_backend::web::api::Implementation;
+
 use super::config::{init_shared_env_configuration, ENV_VAR_E2E_SHARED};
 use crate::common::contexts::settings::Settings;
 use crate::environments::{isolated, shared};
@@ -53,7 +55,7 @@ impl TestEnv {
 
     /// It starts the test environment. It can be a shared or isolated test
     /// environment depending on the value of the `ENV_VAR_E2E_SHARED` env var.
-    pub async fn start(&mut self) {
+    pub async fn start(&mut self, api_implementation: Implementation) {
         let e2e_shared = ENV_VAR_E2E_SHARED; // bool
 
         if let Ok(_e2e_test_env_is_shared) = env::var(e2e_shared) {
@@ -64,7 +66,7 @@ impl TestEnv {
             self.starting_settings = self.server_settings_for_shared_env().await;
         } else {
             // Using an isolated test env.
-            let isolated_env = isolated::TestEnv::running().await;
+            let isolated_env = isolated::TestEnv::running(api_implementation).await;
 
             self.isolated = Some(isolated_env);
             self.starting_settings = self.server_settings_for_isolated_env();

--- a/tests/environments/isolated.rs
+++ b/tests/environments/isolated.rs
@@ -1,6 +1,7 @@
 use tempfile::TempDir;
 use torrust_index_backend::config;
 use torrust_index_backend::config::FREE_PORT;
+use torrust_index_backend::web::api::Implementation;
 
 use super::app_starter::AppStarter;
 use crate::common::random;
@@ -15,9 +16,9 @@ pub struct TestEnv {
 
 impl TestEnv {
     /// Provides a running app instance for integration tests.
-    pub async fn running() -> Self {
+    pub async fn running(api_implementation: Implementation) -> Self {
         let mut env = Self::default();
-        env.start().await;
+        env.start(api_implementation).await;
         env
     }
 
@@ -39,8 +40,8 @@ impl TestEnv {
     }
 
     /// Starts the app.
-    pub async fn start(&mut self) {
-        self.app_starter.start().await;
+    pub async fn start(&mut self, api_implementation: Implementation) {
+        self.app_starter.start(api_implementation).await;
     }
 
     /// Provides the whole server configuration.


### PR DESCRIPTION
Basic changes which are needed to run the Axum API implementation in parallel with the current one with ActixWeb. For the time being the Axum implementation will be only used for testing until all endpoints are migrated.
