### PR TITLE
New config option for log level

### DIFF
--- a/config-idx-back.local.toml
+++ b/config-idx-back.local.toml
@@ -1,3 +1,5 @@
+log_level = "info"
+
 [website]
 name = "Torrust"
 

--- a/config.local.toml
+++ b/config.local.toml
@@ -1,3 +1,5 @@
+log_level = "info"
+
 [website]
 name = "Torrust"
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -30,7 +30,9 @@ pub struct Running {
 
 #[allow(clippy::too_many_lines)]
 pub async fn run(configuration: Configuration, api_implementation: &Implementation) -> Running {
-    logging::setup();
+    let log_level = configuration.settings.read().await.log_level.clone();
+
+    logging::setup(&log_level);
 
     let configuration = Arc::new(configuration);
 

--- a/src/bootstrap/logging.rs
+++ b/src/bootstrap/logging.rs
@@ -13,10 +13,8 @@ use log::{info, LevelFilter};
 
 static INIT: Once = Once::new();
 
-pub fn setup() {
-    // todo: load log level from configuration.
-
-    let level = config_level_or_default(&None);
+pub fn setup(log_level: &Option<String>) {
+    let level = config_level_or_default(log_level);
 
     if level == log::LevelFilter::Off {
         return;

--- a/src/config.rs
+++ b/src/config.rs
@@ -257,6 +257,9 @@ impl Default for ImageCache {
 /// The whole configuration for the backend.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct TorrustBackend {
+    /// Logging level. Possible values are: `Off`, `Error`, `Warn`, `Info`,
+    /// `Debug` and `Trace`. Default is `Info`.
+    pub log_level: Option<String>,
     /// The website customizable values.
     pub website: Website,
     /// The tracker configuration.

--- a/src/console/commands/import_tracker_statistics.rs
+++ b/src/console/commands/import_tracker_statistics.rs
@@ -85,7 +85,9 @@ pub async fn import() {
 
     let configuration = init_configuration().await;
 
-    logging::setup();
+    let log_level = configuration.settings.read().await.log_level.clone();
+
+    logging::setup(&log_level);
 
     let cfg = Arc::new(configuration);
 

--- a/tests/environments/isolated.rs
+++ b/tests/environments/isolated.rs
@@ -70,7 +70,10 @@ impl Default for TestEnv {
 
 /// Provides a configuration with ephemeral data for testing.
 fn ephemeral(temp_dir: &TempDir) -> config::TorrustBackend {
-    let mut configuration = config::TorrustBackend::default();
+    let mut configuration = config::TorrustBackend {
+        log_level: Some("off".to_owned()), // Change to `debug` for tests debugging
+        ..config::TorrustBackend::default()
+    };
 
     // Ephemeral API port
     configuration.net.port = FREE_PORT;


### PR DESCRIPTION
```toml
log_level = "info"
```

The level can be:

- `off`
- `error`
- `warn`
- `info`
- `debug`
- `trace`

It's optional. The default value is `info`.