### PR TITLE
Fix SQL error in SQLite

### DIFF
--- a/src/databases/sqlite.rs
+++ b/src/databases/sqlite.rs
@@ -361,7 +361,7 @@ impl Database for Sqlite {
         };
 
         let mut query_string = format!(
-            "SELECT tt.torrent_id, tp.username AS uploader, tt.info_hash, ti.title, ti.description, tt.category_id, DATE_FORMAT(tt.date_uploaded, '%Y-%m-%d %H:%i:%s') AS date_uploaded, tt.size AS file_size,
+            "SELECT tt.torrent_id, tp.username AS uploader, tt.info_hash, ti.title, ti.description, tt.category_id, tt.date_uploaded, tt.size AS file_size,
             CAST(COALESCE(sum(ts.seeders),0) as signed) as seeders,
             CAST(COALESCE(sum(ts.leechers),0) as signed) as leechers
             FROM torrust_torrents tt


### PR DESCRIPTION
The SQL query:

```sql
SELECT
  COUNT(*) as count
FROM
  (
    SELECT
      tt.torrent_id,
      tp.username AS uploader,
      tt.info_hash,
      ti.title,
      ti.description,
      tt.category_id,
      DATE_FORMAT(tt.date_uploaded, '%Y-%m-%d %H:%i:%s') AS date_uploaded,
      tt.size AS file_size,
      CAST(COALESCE(sum(ts.seeders), 0) as signed) as seeders,
      CAST(COALESCE(sum(ts.leechers), 0) as signed) as leechers
    FROM
      torrust_torrents tt
      INNER JOIN torrust_user_profiles tp ON tt.uploader_id = tp.user_id
      INNER JOIN torrust_torrent_info ti ON tt.torrent_id = ti.torrent_id
      LEFT JOIN torrust_torrent_tracker_stats ts ON tt.torrent_id = ts.torrent_id
    WHERE
      title LIKE ?
    GROUP BY
      tt.torrent_id
  ) AS count_table
```

should not use the `DATE_FORMAT` function in SQLite.