### PR TITLE
Axum API: `root` enpoints

### DIFF
--- a/src/web/api/v1/routes.rs
+++ b/src/web/api/v1/routes.rs
@@ -1,22 +1,27 @@
 //! Route initialization for the v1 API.
 use std::sync::Arc;
 
+use axum::routing::get;
 use axum::Router;
 
 //use tower_http::cors::CorsLayer;
 use super::contexts::about;
+use super::contexts::about::handlers::about_page_handler;
 use super::contexts::{category, user};
 use crate::common::AppData;
 
 /// Add all API routes to the router.
 #[allow(clippy::needless_pass_by_value)]
 pub fn router(app_data: Arc<AppData>) -> Router {
-    let api_routes = Router::new()
+    let v1_api_routes = Router::new()
+        .route("/", get(about_page_handler).with_state(app_data.clone()))
         .nest("/user", user::routes::router(app_data.clone()))
         .nest("/about", about::routes::router(app_data.clone()))
-        .nest("/category", category::routes::router(app_data));
+        .nest("/category", category::routes::router(app_data.clone()));
 
-    Router::new().nest("/v1", api_routes)
+    Router::new()
+        .route("/", get(about_page_handler).with_state(app_data))
+        .nest("/v1", v1_api_routes)
 
     // For development purposes only.
     // It allows calling the API on a different port. For example

--- a/tests/e2e/contexts/root/contract.rs
+++ b/tests/e2e/contexts/root/contract.rs
@@ -16,3 +16,24 @@ async fn it_should_load_the_about_page_at_the_api_entrypoint() {
     assert_text_ok(&response);
     assert_response_title(&response, "About");
 }
+
+mod with_axum_implementation {
+    use torrust_index_backend::web::api;
+
+    use crate::common::asserts::{assert_response_title, assert_text_ok};
+    use crate::common::client::Client;
+    use crate::e2e::environment::TestEnv;
+
+    #[tokio::test]
+    async fn it_should_load_the_about_page_at_the_api_entrypoint() {
+        let mut env = TestEnv::new();
+        env.start(api::Implementation::Axum).await;
+
+        let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
+
+        let response = client.root().await;
+
+        assert_text_ok(&response);
+        assert_response_title(&response, "About");
+    }
+}


### PR DESCRIPTION
API migration to Axum for root endpoints.