### PR TITLE
Axum API: make it the default implementation

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -32,4 +32,4 @@ jobs:
       - name: E2E Tests
         run: ./docker/bin/run-e2e-tests.sh
         env:
-          TORRUST_IDX_BACK_E2E_EXCLUDE_AXUM_IMPL: "true"
+          TORRUST_IDX_BACK_E2E_EXCLUDE_ACTIX_WEB_IMPL: "true"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -6,11 +6,7 @@ use torrust_index_backend::web::api::Implementation;
 async fn main() -> Result<(), std::io::Error> {
     let configuration = init_configuration().await;
 
-    // todo: we are migrating from actix-web to axum, so we need to keep both
-    // implementations for a while. For production we only use ActixWeb.
-    // Once the Axum implementation is finished and stable, we can switch to it
-    // and remove the ActixWeb implementation.
-    let api_implementation = Implementation::ActixWeb;
+    let api_implementation = Implementation::Axum;
 
     let app = app::run(configuration, &api_implementation).await;
 

--- a/tests/e2e/config.rs
+++ b/tests/e2e/config.rs
@@ -14,8 +14,8 @@ pub const ENV_VAR_E2E_SHARED: &str = "TORRUST_IDX_BACK_E2E_SHARED";
 /// The whole `config.toml` file content. It has priority over the config file.
 pub const ENV_VAR_E2E_CONFIG: &str = "TORRUST_IDX_BACK_E2E_CONFIG";
 
-/// If present, E2E tests for new Axum implementation will not be executed
-pub const ENV_VAR_E2E_EXCLUDE_AXUM_IMPL: &str = "TORRUST_IDX_BACK_E2E_EXCLUDE_AXUM_IMPL";
+/// If present, E2E tests for new `ActixWeb` implementation will not be executed
+pub const ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL: &str = "TORRUST_IDX_BACK_E2E_EXCLUDE_ACTIX_WEB_IMPL";
 
 // Default values
 

--- a/tests/e2e/contexts/about/contract.rs
+++ b/tests/e2e/contexts/about/contract.rs
@@ -1,14 +1,23 @@
 //! API contract for `about` context.
+use std::env;
+
 use torrust_index_backend::web::api;
 
 use crate::common::asserts::{assert_response_title, assert_text_ok};
 use crate::common::client::Client;
+use crate::e2e::config::ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL;
 use crate::e2e::environment::TestEnv;
 
 #[tokio::test]
 async fn it_should_load_the_about_page_with_information_about_the_api() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
+
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
+
     let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
     let response = client.about().await;
@@ -21,6 +30,12 @@ async fn it_should_load_the_about_page_with_information_about_the_api() {
 async fn it_should_load_the_license_page_at_the_api_entrypoint() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
+
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
+
     let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
     let response = client.license().await;

--- a/tests/e2e/contexts/category/contract.rs
+++ b/tests/e2e/contexts/category/contract.rs
@@ -1,4 +1,6 @@
 //! API contract for `category` context.
+use std::env;
+
 use torrust_index_backend::web::api;
 
 use crate::common::asserts::assert_json_ok_response;
@@ -6,6 +8,7 @@ use crate::common::client::Client;
 use crate::common::contexts::category::fixtures::random_category_name;
 use crate::common::contexts::category::forms::{AddCategoryForm, DeleteCategoryForm};
 use crate::common::contexts::category::responses::{AddedCategoryResponse, ListResponse};
+use crate::e2e::config::ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL;
 use crate::e2e::contexts::category::steps::{add_category, add_random_category};
 use crate::e2e::contexts::user::steps::{new_logged_in_admin, new_logged_in_user};
 use crate::e2e::environment::TestEnv;
@@ -14,6 +17,12 @@ use crate::e2e::environment::TestEnv;
 async fn it_should_return_an_empty_category_list_when_there_are_no_categories() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
+
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
+
     let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
     let response = client.get_categories().await;
@@ -25,6 +34,12 @@ async fn it_should_return_an_empty_category_list_when_there_are_no_categories() 
 async fn it_should_return_a_category_list() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
+
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
+
     let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
     add_random_category(&env).await;
@@ -47,6 +62,12 @@ async fn it_should_return_a_category_list() {
 async fn it_should_not_allow_adding_a_new_category_to_unauthenticated_users() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
+
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
+
     let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
     let response = client
@@ -63,6 +84,11 @@ async fn it_should_not_allow_adding_a_new_category_to_unauthenticated_users() {
 async fn it_should_not_allow_adding_a_new_category_to_non_admins() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
+
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
 
     let logged_non_admin = new_logged_in_user(&env).await;
 
@@ -82,6 +108,11 @@ async fn it_should_not_allow_adding_a_new_category_to_non_admins() {
 async fn it_should_allow_admins_to_add_new_categories() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
+
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
 
     let logged_in_admin = new_logged_in_admin(&env).await;
     let client = Client::authenticated(&env.server_socket_addr().unwrap(), &logged_in_admin.token);
@@ -110,6 +141,11 @@ async fn it_should_allow_adding_empty_categories() {
 
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
+
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
 
     if env.is_shared() {
         // This test cannot be run in a shared test env because it will fail
@@ -144,6 +180,11 @@ async fn it_should_not_allow_adding_duplicated_categories() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
 
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
+
     let added_category_name = add_random_category(&env).await;
 
     // Try to add the same category again
@@ -155,6 +196,11 @@ async fn it_should_not_allow_adding_duplicated_categories() {
 async fn it_should_allow_admins_to_delete_categories() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
+
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
 
     let logged_in_admin = new_logged_in_admin(&env).await;
     let client = Client::authenticated(&env.server_socket_addr().unwrap(), &logged_in_admin.token);
@@ -182,6 +228,11 @@ async fn it_should_not_allow_non_admins_to_delete_categories() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
 
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
+
     let added_category_name = add_random_category(&env).await;
 
     let logged_in_non_admin = new_logged_in_user(&env).await;
@@ -201,6 +252,12 @@ async fn it_should_not_allow_non_admins_to_delete_categories() {
 async fn it_should_not_allow_guests_to_delete_categories() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
+
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
+
     let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
     let added_category_name = add_random_category(&env).await;
@@ -216,7 +273,6 @@ async fn it_should_not_allow_guests_to_delete_categories() {
 }
 
 mod with_axum_implementation {
-    use std::env;
 
     use torrust_index_backend::web::api;
 
@@ -226,7 +282,6 @@ mod with_axum_implementation {
     use crate::common::contexts::category::fixtures::random_category_name;
     use crate::common::contexts::category::forms::{AddCategoryForm, DeleteCategoryForm};
     use crate::common::contexts::category::responses::ListResponse;
-    use crate::e2e::config::ENV_VAR_E2E_EXCLUDE_AXUM_IMPL;
     use crate::e2e::contexts::category::steps::{add_category, add_random_category};
     use crate::e2e::contexts::user::steps::{new_logged_in_admin, new_logged_in_user};
     use crate::e2e::environment::TestEnv;
@@ -247,11 +302,6 @@ mod with_axum_implementation {
     async fn it_should_return_a_category_list() {
         let mut env = TestEnv::new();
         env.start(api::Implementation::Axum).await;
-
-        if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-            println!("Skipped");
-            return;
-        }
 
         let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
@@ -276,11 +326,6 @@ mod with_axum_implementation {
         let mut env = TestEnv::new();
         env.start(api::Implementation::Axum).await;
 
-        if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-            println!("Skipped");
-            return;
-        }
-
         let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
         let response = client
@@ -297,11 +342,6 @@ mod with_axum_implementation {
     async fn it_should_not_allow_adding_a_new_category_to_non_admins() {
         let mut env = TestEnv::new();
         env.start(api::Implementation::Axum).await;
-
-        if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-            println!("Skipped");
-            return;
-        }
 
         let logged_non_admin = new_logged_in_user(&env).await;
 
@@ -321,11 +361,6 @@ mod with_axum_implementation {
     async fn it_should_allow_admins_to_add_new_categories() {
         let mut env = TestEnv::new();
         env.start(api::Implementation::Axum).await;
-
-        if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-            println!("Skipped");
-            return;
-        }
 
         let logged_in_admin = new_logged_in_admin(&env).await;
         let client = Client::authenticated(&env.server_socket_addr().unwrap(), &logged_in_admin.token);
@@ -356,11 +391,6 @@ mod with_axum_implementation {
             return;
         }
 
-        if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-            println!("Skipped");
-            return;
-        }
-
         let logged_in_admin = new_logged_in_admin(&env).await;
         let client = Client::authenticated(&env.server_socket_addr().unwrap(), &logged_in_admin.token);
 
@@ -381,11 +411,6 @@ mod with_axum_implementation {
         let mut env = TestEnv::new();
         env.start(api::Implementation::Axum).await;
 
-        if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-            println!("Skipped");
-            return;
-        }
-
         let added_category_name = add_random_category(&env).await;
 
         // Try to add the same category again
@@ -398,11 +423,6 @@ mod with_axum_implementation {
     async fn it_should_allow_admins_to_delete_categories() {
         let mut env = TestEnv::new();
         env.start(api::Implementation::Axum).await;
-
-        if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-            println!("Skipped");
-            return;
-        }
 
         let logged_in_admin = new_logged_in_admin(&env).await;
         let client = Client::authenticated(&env.server_socket_addr().unwrap(), &logged_in_admin.token);
@@ -424,11 +444,6 @@ mod with_axum_implementation {
         let mut env = TestEnv::new();
         env.start(api::Implementation::Axum).await;
 
-        if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-            println!("Skipped");
-            return;
-        }
-
         let added_category_name = add_random_category(&env).await;
 
         let logged_in_non_admin = new_logged_in_user(&env).await;
@@ -448,11 +463,6 @@ mod with_axum_implementation {
     async fn it_should_not_allow_guests_to_delete_categories() {
         let mut env = TestEnv::new();
         env.start(api::Implementation::Axum).await;
-
-        if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-            println!("Skipped");
-            return;
-        }
 
         let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 

--- a/tests/e2e/contexts/root/contract.rs
+++ b/tests/e2e/contexts/root/contract.rs
@@ -1,14 +1,23 @@
 //! API contract for `root` context.
+use std::env;
+
 use torrust_index_backend::web::api;
 
 use crate::common::asserts::{assert_response_title, assert_text_ok};
 use crate::common::client::Client;
+use crate::e2e::config::ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL;
 use crate::e2e::environment::TestEnv;
 
 #[tokio::test]
 async fn it_should_load_the_about_page_at_the_api_entrypoint() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
+
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
+
     let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
     let response = client.root().await;

--- a/tests/e2e/contexts/settings/contract.rs
+++ b/tests/e2e/contexts/settings/contract.rs
@@ -1,7 +1,10 @@
+use std::env;
+
 use torrust_index_backend::web::api;
 
 use crate::common::client::Client;
 use crate::common::contexts::settings::responses::{AllSettingsResponse, Public, PublicSettingsResponse, SiteNameResponse};
+use crate::e2e::config::ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL;
 use crate::e2e::contexts::user::steps::new_logged_in_admin;
 use crate::e2e::environment::TestEnv;
 
@@ -9,6 +12,12 @@ use crate::e2e::environment::TestEnv;
 async fn it_should_allow_guests_to_get_the_public_settings() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
+
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
+
     let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
     let response = client.get_public_settings().await;
@@ -34,6 +43,12 @@ async fn it_should_allow_guests_to_get_the_public_settings() {
 async fn it_should_allow_guests_to_get_the_site_name() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
+
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
+
     let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
     let response = client.get_site_name().await;
@@ -51,6 +66,11 @@ async fn it_should_allow_guests_to_get_the_site_name() {
 async fn it_should_allow_admins_to_get_all_the_settings() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
+
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
 
     let logged_in_admin = new_logged_in_admin(&env).await;
     let client = Client::authenticated(&env.server_socket_addr().unwrap(), &logged_in_admin.token);
@@ -70,6 +90,11 @@ async fn it_should_allow_admins_to_get_all_the_settings() {
 async fn it_should_allow_admins_to_update_all_the_settings() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
+
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
 
     if !env.is_isolated() {
         // This test can't be executed in a non-isolated environment because
@@ -96,14 +121,12 @@ async fn it_should_allow_admins_to_update_all_the_settings() {
 }
 
 mod with_axum_implementation {
-    use std::env;
 
     use torrust_index_backend::web::api;
 
     use crate::common::asserts::assert_json_ok_response;
     use crate::common::client::Client;
     use crate::common::contexts::settings::responses::{AllSettingsResponse, Public, PublicSettingsResponse, SiteNameResponse};
-    use crate::e2e::config::ENV_VAR_E2E_EXCLUDE_AXUM_IMPL;
     use crate::e2e::contexts::user::steps::new_logged_in_admin;
     use crate::e2e::environment::TestEnv;
 
@@ -111,11 +134,6 @@ mod with_axum_implementation {
     async fn it_should_allow_guests_to_get_the_public_settings() {
         let mut env = TestEnv::new();
         env.start(api::Implementation::Axum).await;
-
-        if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-            println!("Skipped");
-            return;
-        }
 
         let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
@@ -142,11 +160,6 @@ mod with_axum_implementation {
         let mut env = TestEnv::new();
         env.start(api::Implementation::Axum).await;
 
-        if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-            println!("Skipped");
-            return;
-        }
-
         let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
         let response = client.get_site_name().await;
@@ -162,11 +175,6 @@ mod with_axum_implementation {
     async fn it_should_allow_admins_to_get_all_the_settings() {
         let mut env = TestEnv::new();
         env.start(api::Implementation::Axum).await;
-
-        if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-            println!("Skipped");
-            return;
-        }
 
         let logged_in_admin = new_logged_in_admin(&env).await;
         let client = Client::authenticated(&env.server_socket_addr().unwrap(), &logged_in_admin.token);
@@ -184,11 +192,6 @@ mod with_axum_implementation {
     async fn it_should_allow_admins_to_update_all_the_settings() {
         let mut env = TestEnv::new();
         env.start(api::Implementation::Axum).await;
-
-        if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-            println!("Skipped");
-            return;
-        }
 
         if !env.is_isolated() {
             // This test can't be executed in a non-isolated environment because

--- a/tests/e2e/contexts/tag/contract.rs
+++ b/tests/e2e/contexts/tag/contract.rs
@@ -1,4 +1,6 @@
 //! API contract for `tag` context.
+use std::env;
+
 use torrust_index_backend::web::api;
 
 use crate::common::asserts::assert_json_ok_response;
@@ -6,6 +8,7 @@ use crate::common::client::Client;
 use crate::common::contexts::tag::fixtures::random_tag_name;
 use crate::common::contexts::tag::forms::{AddTagForm, DeleteTagForm};
 use crate::common::contexts::tag::responses::{AddedTagResponse, DeletedTagResponse, ListResponse};
+use crate::e2e::config::ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL;
 use crate::e2e::contexts::tag::steps::{add_random_tag, add_tag};
 use crate::e2e::contexts::user::steps::{new_logged_in_admin, new_logged_in_user};
 use crate::e2e::environment::TestEnv;
@@ -14,6 +17,12 @@ use crate::e2e::environment::TestEnv;
 async fn it_should_return_an_empty_tag_list_when_there_are_no_tags() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
+
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
+
     let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
     let response = client.get_tags().await;
@@ -25,6 +34,12 @@ async fn it_should_return_an_empty_tag_list_when_there_are_no_tags() {
 async fn it_should_return_a_tag_list() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
+
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
+
     let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
     // Add a tag
@@ -50,6 +65,12 @@ async fn it_should_return_a_tag_list() {
 async fn it_should_not_allow_adding_a_new_tag_to_unauthenticated_users() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
+
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
+
     let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
     let response = client
@@ -65,6 +86,11 @@ async fn it_should_not_allow_adding_a_new_tag_to_unauthenticated_users() {
 async fn it_should_not_allow_adding_a_new_tag_to_non_admins() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
+
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
 
     let logged_non_admin = new_logged_in_user(&env).await;
 
@@ -83,6 +109,11 @@ async fn it_should_not_allow_adding_a_new_tag_to_non_admins() {
 async fn it_should_allow_admins_to_add_new_tags() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
+
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
 
     let logged_in_admin = new_logged_in_admin(&env).await;
     let client = Client::authenticated(&env.server_socket_addr().unwrap(), &logged_in_admin.token);
@@ -111,6 +142,11 @@ async fn it_should_allow_adding_duplicated_tags() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
 
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
+
     // Add a tag
     let random_tag_name = random_tag_name();
     let response = add_tag(&random_tag_name, &env).await;
@@ -128,6 +164,11 @@ async fn it_should_allow_adding_a_tag_with_an_empty_name() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
 
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
+
     let empty_tag_name = String::new();
     let response = add_tag(&empty_tag_name, &env).await;
     assert_eq!(response.status, 200);
@@ -137,6 +178,11 @@ async fn it_should_allow_adding_a_tag_with_an_empty_name() {
 async fn it_should_allow_admins_to_delete_tags() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
+
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
 
     let logged_in_admin = new_logged_in_admin(&env).await;
     let client = Client::authenticated(&env.server_socket_addr().unwrap(), &logged_in_admin.token);
@@ -159,6 +205,11 @@ async fn it_should_not_allow_non_admins_to_delete_tags() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
 
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
+
     let logged_in_non_admin = new_logged_in_user(&env).await;
     let client = Client::authenticated(&env.server_socket_addr().unwrap(), &logged_in_non_admin.token);
 
@@ -173,6 +224,12 @@ async fn it_should_not_allow_non_admins_to_delete_tags() {
 async fn it_should_not_allow_guests_to_delete_tags() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
+
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
+
     let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
     let (tag_id, _tag_name) = add_random_tag(&env).await;
@@ -183,7 +240,6 @@ async fn it_should_not_allow_guests_to_delete_tags() {
 }
 
 mod with_axum_implementation {
-    use std::env;
 
     use torrust_index_backend::web::api;
 
@@ -193,7 +249,6 @@ mod with_axum_implementation {
     use crate::common::contexts::tag::fixtures::random_tag_name;
     use crate::common::contexts::tag::forms::{AddTagForm, DeleteTagForm};
     use crate::common::contexts::tag::responses::ListResponse;
-    use crate::e2e::config::ENV_VAR_E2E_EXCLUDE_AXUM_IMPL;
     use crate::e2e::contexts::tag::steps::{add_random_tag, add_tag};
     use crate::e2e::contexts::user::steps::{new_logged_in_admin, new_logged_in_user};
     use crate::e2e::environment::TestEnv;
@@ -202,11 +257,6 @@ mod with_axum_implementation {
     async fn it_should_return_an_empty_tag_list_when_there_are_no_tags() {
         let mut env = TestEnv::new();
         env.start(api::Implementation::Axum).await;
-
-        if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-            println!("Skipped");
-            return;
-        }
 
         let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
@@ -219,11 +269,6 @@ mod with_axum_implementation {
     async fn it_should_return_a_tag_list() {
         let mut env = TestEnv::new();
         env.start(api::Implementation::Axum).await;
-
-        if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-            println!("Skipped");
-            return;
-        }
 
         let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
@@ -251,11 +296,6 @@ mod with_axum_implementation {
         let mut env = TestEnv::new();
         env.start(api::Implementation::Axum).await;
 
-        if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-            println!("Skipped");
-            return;
-        }
-
         let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
         let response = client
@@ -271,11 +311,6 @@ mod with_axum_implementation {
     async fn it_should_not_allow_adding_a_new_tag_to_non_admins() {
         let mut env = TestEnv::new();
         env.start(api::Implementation::Axum).await;
-
-        if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-            println!("Skipped");
-            return;
-        }
 
         let logged_non_admin = new_logged_in_user(&env).await;
 
@@ -294,11 +329,6 @@ mod with_axum_implementation {
     async fn it_should_allow_admins_to_add_new_tags() {
         let mut env = TestEnv::new();
         env.start(api::Implementation::Axum).await;
-
-        if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-            println!("Skipped");
-            return;
-        }
 
         let logged_in_admin = new_logged_in_admin(&env).await;
         let client = Client::authenticated(&env.server_socket_addr().unwrap(), &logged_in_admin.token);
@@ -321,11 +351,6 @@ mod with_axum_implementation {
         let mut env = TestEnv::new();
         env.start(api::Implementation::Axum).await;
 
-        if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-            println!("Skipped");
-            return;
-        }
-
         // Add a tag
         let random_tag_name = random_tag_name();
         let response = add_tag(&random_tag_name, &env).await;
@@ -343,11 +368,6 @@ mod with_axum_implementation {
         let mut env = TestEnv::new();
         env.start(api::Implementation::Axum).await;
 
-        if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-            println!("Skipped");
-            return;
-        }
-
         let empty_tag_name = String::new();
         let response = add_tag(&empty_tag_name, &env).await;
         assert_eq!(response.status, 200);
@@ -357,11 +377,6 @@ mod with_axum_implementation {
     async fn it_should_allow_admins_to_delete_tags() {
         let mut env = TestEnv::new();
         env.start(api::Implementation::Axum).await;
-
-        if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-            println!("Skipped");
-            return;
-        }
 
         let logged_in_admin = new_logged_in_admin(&env).await;
         let client = Client::authenticated(&env.server_socket_addr().unwrap(), &logged_in_admin.token);
@@ -378,11 +393,6 @@ mod with_axum_implementation {
         let mut env = TestEnv::new();
         env.start(api::Implementation::Axum).await;
 
-        if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-            println!("Skipped");
-            return;
-        }
-
         let logged_in_non_admin = new_logged_in_user(&env).await;
         let client = Client::authenticated(&env.server_socket_addr().unwrap(), &logged_in_non_admin.token);
 
@@ -397,11 +407,6 @@ mod with_axum_implementation {
     async fn it_should_not_allow_guests_to_delete_tags() {
         let mut env = TestEnv::new();
         env.start(api::Implementation::Axum).await;
-
-        if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-            println!("Skipped");
-            return;
-        }
 
         let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 

--- a/tests/e2e/contexts/torrent/contract.rs
+++ b/tests/e2e/contexts/torrent/contract.rs
@@ -15,6 +15,8 @@ Get torrent info:
 */
 
 mod for_guests {
+    use std::env;
+
     use torrust_index_backend::utils::parse_torrent::decode_torrent;
     use torrust_index_backend::web::api;
 
@@ -26,6 +28,7 @@ mod for_guests {
         Category, File, TorrentDetails, TorrentDetailsResponse, TorrentListResponse,
     };
     use crate::common::http::{Query, QueryParam};
+    use crate::e2e::config::ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL;
     use crate::e2e::contexts::torrent::asserts::expected_torrent;
     use crate::e2e::contexts::torrent::steps::upload_random_torrent_to_index;
     use crate::e2e::contexts::user::steps::new_logged_in_user;
@@ -35,6 +38,11 @@ mod for_guests {
     async fn it_should_allow_guests_to_get_torrents() {
         let mut env = TestEnv::new();
         env.start(api::Implementation::ActixWeb).await;
+
+        if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+            println!("Skipped");
+            return;
+        }
 
         if !env.provides_a_tracker() {
             println!("test skipped. It requires a tracker to be running.");
@@ -58,6 +66,11 @@ mod for_guests {
     async fn it_should_allow_to_get_torrents_with_pagination() {
         let mut env = TestEnv::new();
         env.start(api::Implementation::ActixWeb).await;
+
+        if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+            println!("Skipped");
+            return;
+        }
 
         if !env.provides_a_tracker() {
             println!("test skipped. It requires a tracker to be running.");
@@ -88,6 +101,11 @@ mod for_guests {
     async fn it_should_allow_to_limit_the_number_of_torrents_per_request() {
         let mut env = TestEnv::new();
         env.start(api::Implementation::ActixWeb).await;
+
+        if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+            println!("Skipped");
+            return;
+        }
 
         if !env.provides_a_tracker() {
             println!("test skipped. It requires a tracker to be running.");
@@ -124,6 +142,11 @@ mod for_guests {
         let mut env = TestEnv::new();
         env.start(api::Implementation::ActixWeb).await;
 
+        if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+            println!("Skipped");
+            return;
+        }
+
         if !env.provides_a_tracker() {
             println!("test skipped. It requires a tracker to be running.");
             return;
@@ -154,6 +177,11 @@ mod for_guests {
     async fn it_should_allow_guests_to_get_torrent_details_searching_by_info_hash() {
         let mut env = TestEnv::new();
         env.start(api::Implementation::ActixWeb).await;
+
+        if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+            println!("Skipped");
+            return;
+        }
 
         if !env.provides_a_tracker() {
             println!("test skipped. It requires a tracker to be running.");
@@ -218,6 +246,11 @@ mod for_guests {
         let mut env = TestEnv::new();
         env.start(api::Implementation::ActixWeb).await;
 
+        if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+            println!("Skipped");
+            return;
+        }
+
         if !env.provides_a_tracker() {
             println!("test skipped. It requires a tracker to be running.");
             return;
@@ -243,6 +276,11 @@ mod for_guests {
         let mut env = TestEnv::new();
         env.start(api::Implementation::ActixWeb).await;
 
+        if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+            println!("Skipped");
+            return;
+        }
+
         if !env.provides_a_tracker() {
             println!("test skipped. It requires a tracker to be running.");
             return;
@@ -263,6 +301,11 @@ mod for_guests {
         let mut env = TestEnv::new();
         env.start(api::Implementation::ActixWeb).await;
 
+        if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+            println!("Skipped");
+            return;
+        }
+
         if !env.provides_a_tracker() {
             println!("test skipped. It requires a tracker to be running.");
             return;
@@ -281,6 +324,8 @@ mod for_guests {
 
 mod for_authenticated_users {
 
+    use std::env;
+
     use torrust_index_backend::utils::parse_torrent::decode_torrent;
     use torrust_index_backend::web::api;
 
@@ -288,6 +333,7 @@ mod for_authenticated_users {
     use crate::common::contexts::torrent::fixtures::random_torrent;
     use crate::common::contexts::torrent::forms::UploadTorrentMultipartForm;
     use crate::common::contexts::torrent::responses::UploadedTorrentResponse;
+    use crate::e2e::config::ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL;
     use crate::e2e::contexts::torrent::asserts::{build_announce_url, get_user_tracker_key};
     use crate::e2e::contexts::torrent::steps::upload_random_torrent_to_index;
     use crate::e2e::contexts::user::steps::new_logged_in_user;
@@ -297,6 +343,11 @@ mod for_authenticated_users {
     async fn it_should_allow_authenticated_users_to_upload_new_torrents() {
         let mut env = TestEnv::new();
         env.start(api::Implementation::ActixWeb).await;
+
+        if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+            println!("Skipped");
+            return;
+        }
 
         if !env.provides_a_tracker() {
             println!("test skipped. It requires a tracker to be running.");
@@ -327,6 +378,11 @@ mod for_authenticated_users {
         let mut env = TestEnv::new();
         env.start(api::Implementation::ActixWeb).await;
 
+        if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+            println!("Skipped");
+            return;
+        }
+
         let uploader = new_logged_in_user(&env).await;
         let client = Client::authenticated(&env.server_socket_addr().unwrap(), &uploader.token);
 
@@ -345,6 +401,11 @@ mod for_authenticated_users {
     async fn it_should_not_allow_uploading_a_torrent_with_a_title_that_already_exists() {
         let mut env = TestEnv::new();
         env.start(api::Implementation::ActixWeb).await;
+
+        if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+            println!("Skipped");
+            return;
+        }
 
         if !env.provides_a_tracker() {
             println!("test skipped. It requires a tracker to be running.");
@@ -375,6 +436,11 @@ mod for_authenticated_users {
         let mut env = TestEnv::new();
         env.start(api::Implementation::ActixWeb).await;
 
+        if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+            println!("Skipped");
+            return;
+        }
+
         if !env.provides_a_tracker() {
             println!("test skipped. It requires a tracker to be running.");
             return;
@@ -404,6 +470,11 @@ mod for_authenticated_users {
     async fn it_should_allow_authenticated_users_to_download_a_torrent_with_a_personal_announce_url() {
         let mut env = TestEnv::new();
         env.start(api::Implementation::ActixWeb).await;
+
+        if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+            println!("Skipped");
+            return;
+        }
 
         if !env.provides_a_tracker() {
             println!("test skipped. It requires a tracker to be running.");
@@ -437,10 +508,13 @@ mod for_authenticated_users {
     }
 
     mod and_non_admins {
+        use std::env;
+
         use torrust_index_backend::web::api;
 
         use crate::common::client::Client;
         use crate::common::contexts::torrent::forms::UpdateTorrentFrom;
+        use crate::e2e::config::ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL;
         use crate::e2e::contexts::torrent::steps::upload_random_torrent_to_index;
         use crate::e2e::contexts::user::steps::new_logged_in_user;
         use crate::e2e::environment::TestEnv;
@@ -449,6 +523,11 @@ mod for_authenticated_users {
         async fn it_should_not_allow_non_admins_to_delete_torrents() {
             let mut env = TestEnv::new();
             env.start(api::Implementation::ActixWeb).await;
+
+            if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+                println!("Skipped");
+                return;
+            }
 
             if !env.provides_a_tracker() {
                 println!("test skipped. It requires a tracker to be running.");
@@ -469,6 +548,11 @@ mod for_authenticated_users {
         async fn it_should_allow_non_admin_users_to_update_someone_elses_torrents() {
             let mut env = TestEnv::new();
             env.start(api::Implementation::ActixWeb).await;
+
+            if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+                println!("Skipped");
+                return;
+            }
 
             if !env.provides_a_tracker() {
                 println!("test skipped. It requires a tracker to be running.");
@@ -501,11 +585,14 @@ mod for_authenticated_users {
     }
 
     mod and_torrent_owners {
+        use std::env;
+
         use torrust_index_backend::web::api;
 
         use crate::common::client::Client;
         use crate::common::contexts::torrent::forms::UpdateTorrentFrom;
         use crate::common::contexts::torrent::responses::UpdatedTorrentResponse;
+        use crate::e2e::config::ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL;
         use crate::e2e::contexts::torrent::steps::upload_random_torrent_to_index;
         use crate::e2e::contexts::user::steps::new_logged_in_user;
         use crate::e2e::environment::TestEnv;
@@ -514,6 +601,11 @@ mod for_authenticated_users {
         async fn it_should_allow_torrent_owners_to_update_their_torrents() {
             let mut env = TestEnv::new();
             env.start(api::Implementation::ActixWeb).await;
+
+            if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+                println!("Skipped");
+                return;
+            }
 
             if !env.provides_a_tracker() {
                 println!("test skipped. It requires a tracker to be running.");
@@ -549,11 +641,14 @@ mod for_authenticated_users {
     }
 
     mod and_admins {
+        use std::env;
+
         use torrust_index_backend::web::api;
 
         use crate::common::client::Client;
         use crate::common::contexts::torrent::forms::UpdateTorrentFrom;
         use crate::common::contexts::torrent::responses::{DeletedTorrentResponse, UpdatedTorrentResponse};
+        use crate::e2e::config::ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL;
         use crate::e2e::contexts::torrent::steps::upload_random_torrent_to_index;
         use crate::e2e::contexts::user::steps::{new_logged_in_admin, new_logged_in_user};
         use crate::e2e::environment::TestEnv;
@@ -562,6 +657,11 @@ mod for_authenticated_users {
         async fn it_should_allow_admins_to_delete_torrents_searching_by_info_hash() {
             let mut env = TestEnv::new();
             env.start(api::Implementation::ActixWeb).await;
+
+            if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+                println!("Skipped");
+                return;
+            }
 
             if !env.provides_a_tracker() {
                 println!("test skipped. It requires a tracker to be running.");
@@ -586,6 +686,11 @@ mod for_authenticated_users {
         async fn it_should_allow_admins_to_update_someone_elses_torrents() {
             let mut env = TestEnv::new();
             env.start(api::Implementation::ActixWeb).await;
+
+            if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+                println!("Skipped");
+                return;
+            }
 
             if !env.provides_a_tracker() {
                 println!("test skipped. It requires a tracker to be running.");
@@ -626,8 +731,6 @@ mod with_axum_implementation {
 
     mod for_guests {
 
-        use std::env;
-
         use torrust_index_backend::utils::parse_torrent::decode_torrent;
         use torrust_index_backend::web::api;
 
@@ -639,7 +742,6 @@ mod with_axum_implementation {
             Category, File, TorrentDetails, TorrentDetailsResponse, TorrentListResponse,
         };
         use crate::common::http::{Query, QueryParam};
-        use crate::e2e::config::ENV_VAR_E2E_EXCLUDE_AXUM_IMPL;
         use crate::e2e::contexts::torrent::asserts::expected_torrent;
         use crate::e2e::contexts::torrent::steps::upload_random_torrent_to_index;
         use crate::e2e::contexts::user::steps::new_logged_in_user;
@@ -649,11 +751,6 @@ mod with_axum_implementation {
         async fn it_should_allow_guests_to_get_torrents() {
             let mut env = TestEnv::new();
             env.start(api::Implementation::Axum).await;
-
-            if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-                println!("Skipped");
-                return;
-            }
 
             if !env.provides_a_tracker() {
                 println!("test skipped. It requires a tracker to be running.");
@@ -677,11 +774,6 @@ mod with_axum_implementation {
         async fn it_should_allow_to_get_torrents_with_pagination() {
             let mut env = TestEnv::new();
             env.start(api::Implementation::Axum).await;
-
-            if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-                println!("Skipped");
-                return;
-            }
 
             if !env.provides_a_tracker() {
                 println!("test skipped. It requires a tracker to be running.");
@@ -712,11 +804,6 @@ mod with_axum_implementation {
         async fn it_should_allow_to_limit_the_number_of_torrents_per_request() {
             let mut env = TestEnv::new();
             env.start(api::Implementation::Axum).await;
-
-            if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-                println!("Skipped");
-                return;
-            }
 
             if !env.provides_a_tracker() {
                 println!("test skipped. It requires a tracker to be running.");
@@ -753,11 +840,6 @@ mod with_axum_implementation {
             let mut env = TestEnv::new();
             env.start(api::Implementation::Axum).await;
 
-            if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-                println!("Skipped");
-                return;
-            }
-
             if !env.provides_a_tracker() {
                 println!("test skipped. It requires a tracker to be running.");
                 return;
@@ -788,11 +870,6 @@ mod with_axum_implementation {
         async fn it_should_allow_guests_to_get_torrent_details_searching_by_info_hash() {
             let mut env = TestEnv::new();
             env.start(api::Implementation::Axum).await;
-
-            if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-                println!("Skipped");
-                return;
-            }
 
             if !env.provides_a_tracker() {
                 println!("test skipped. It requires a tracker to be running.");
@@ -857,11 +934,6 @@ mod with_axum_implementation {
             let mut env = TestEnv::new();
             env.start(api::Implementation::Axum).await;
 
-            if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-                println!("Skipped");
-                return;
-            }
-
             if !env.provides_a_tracker() {
                 println!("test skipped. It requires a tracker to be running.");
                 return;
@@ -887,11 +959,6 @@ mod with_axum_implementation {
             let mut env = TestEnv::new();
             env.start(api::Implementation::Axum).await;
 
-            if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-                println!("Skipped");
-                return;
-            }
-
             if !env.provides_a_tracker() {
                 println!("test skipped. It requires a tracker to be running.");
                 return;
@@ -912,11 +979,6 @@ mod with_axum_implementation {
             let mut env = TestEnv::new();
             env.start(api::Implementation::Axum).await;
 
-            if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-                println!("Skipped");
-                return;
-            }
-
             if !env.provides_a_tracker() {
                 println!("test skipped. It requires a tracker to be running.");
                 return;
@@ -935,8 +997,6 @@ mod with_axum_implementation {
 
     mod for_authenticated_users {
 
-        use std::env;
-
         use torrust_index_backend::utils::parse_torrent::decode_torrent;
         use torrust_index_backend::web::api;
 
@@ -945,7 +1005,6 @@ mod with_axum_implementation {
         use crate::common::contexts::torrent::fixtures::random_torrent;
         use crate::common::contexts::torrent::forms::UploadTorrentMultipartForm;
         use crate::common::contexts::torrent::responses::UploadedTorrentResponse;
-        use crate::e2e::config::ENV_VAR_E2E_EXCLUDE_AXUM_IMPL;
         use crate::e2e::contexts::torrent::asserts::{build_announce_url, get_user_tracker_key};
         use crate::e2e::contexts::torrent::steps::upload_random_torrent_to_index;
         use crate::e2e::contexts::user::steps::new_logged_in_user;
@@ -955,11 +1014,6 @@ mod with_axum_implementation {
         async fn it_should_allow_authenticated_users_to_upload_new_torrents() {
             let mut env = TestEnv::new();
             env.start(api::Implementation::Axum).await;
-
-            if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-                println!("Skipped");
-                return;
-            }
 
             if !env.provides_a_tracker() {
                 println!("test skipped. It requires a tracker to be running.");
@@ -990,11 +1044,6 @@ mod with_axum_implementation {
             let mut env = TestEnv::new();
             env.start(api::Implementation::Axum).await;
 
-            if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-                println!("Skipped");
-                return;
-            }
-
             let uploader = new_logged_in_user(&env).await;
             let client = Client::authenticated(&env.server_socket_addr().unwrap(), &uploader.token);
 
@@ -1013,11 +1062,6 @@ mod with_axum_implementation {
         async fn it_should_not_allow_uploading_a_torrent_with_a_title_that_already_exists() {
             let mut env = TestEnv::new();
             env.start(api::Implementation::Axum).await;
-
-            if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-                println!("Skipped");
-                return;
-            }
 
             if !env.provides_a_tracker() {
                 println!("test skipped. It requires a tracker to be running.");
@@ -1046,11 +1090,6 @@ mod with_axum_implementation {
         async fn it_should_not_allow_uploading_a_torrent_with_a_info_hash_that_already_exists() {
             let mut env = TestEnv::new();
             env.start(api::Implementation::Axum).await;
-
-            if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-                println!("Skipped");
-                return;
-            }
 
             if !env.provides_a_tracker() {
                 println!("test skipped. It requires a tracker to be running.");
@@ -1081,11 +1120,6 @@ mod with_axum_implementation {
         async fn it_should_allow_authenticated_users_to_download_a_torrent_with_a_personal_announce_url() {
             let mut env = TestEnv::new();
             env.start(api::Implementation::Axum).await;
-
-            if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-                println!("Skipped");
-                return;
-            }
 
             if !env.provides_a_tracker() {
                 println!("test skipped. It requires a tracker to be running.");
@@ -1120,13 +1154,10 @@ mod with_axum_implementation {
 
         mod and_non_admins {
 
-            use std::env;
-
             use torrust_index_backend::web::api;
 
             use crate::common::client::Client;
             use crate::common::contexts::torrent::forms::UpdateTorrentFrom;
-            use crate::e2e::config::ENV_VAR_E2E_EXCLUDE_AXUM_IMPL;
             use crate::e2e::contexts::torrent::steps::upload_random_torrent_to_index;
             use crate::e2e::contexts::user::steps::new_logged_in_user;
             use crate::e2e::environment::TestEnv;
@@ -1135,11 +1166,6 @@ mod with_axum_implementation {
             async fn it_should_not_allow_non_admins_to_delete_torrents() {
                 let mut env = TestEnv::new();
                 env.start(api::Implementation::Axum).await;
-
-                if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-                    println!("Skipped");
-                    return;
-                }
 
                 if !env.provides_a_tracker() {
                     println!("test skipped. It requires a tracker to be running.");
@@ -1160,11 +1186,6 @@ mod with_axum_implementation {
             async fn it_should_allow_non_admin_users_to_update_someone_elses_torrents() {
                 let mut env = TestEnv::new();
                 env.start(api::Implementation::Axum).await;
-
-                if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-                    println!("Skipped");
-                    return;
-                }
 
                 if !env.provides_a_tracker() {
                     println!("test skipped. It requires a tracker to be running.");
@@ -1198,14 +1219,11 @@ mod with_axum_implementation {
 
         mod and_torrent_owners {
 
-            use std::env;
-
             use torrust_index_backend::web::api;
 
             use crate::common::client::Client;
             use crate::common::contexts::torrent::forms::UpdateTorrentFrom;
             use crate::common::contexts::torrent::responses::UpdatedTorrentResponse;
-            use crate::e2e::config::ENV_VAR_E2E_EXCLUDE_AXUM_IMPL;
             use crate::e2e::contexts::torrent::steps::upload_random_torrent_to_index;
             use crate::e2e::contexts::user::steps::new_logged_in_user;
             use crate::e2e::environment::TestEnv;
@@ -1214,11 +1232,6 @@ mod with_axum_implementation {
             async fn it_should_allow_torrent_owners_to_update_their_torrents() {
                 let mut env = TestEnv::new();
                 env.start(api::Implementation::Axum).await;
-
-                if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-                    println!("Skipped");
-                    return;
-                }
 
                 if !env.provides_a_tracker() {
                     println!("test skipped. It requires a tracker to be running.");
@@ -1255,14 +1268,11 @@ mod with_axum_implementation {
 
         mod and_admins {
 
-            use std::env;
-
             use torrust_index_backend::web::api;
 
             use crate::common::client::Client;
             use crate::common::contexts::torrent::forms::UpdateTorrentFrom;
             use crate::common::contexts::torrent::responses::{DeletedTorrentResponse, UpdatedTorrentResponse};
-            use crate::e2e::config::ENV_VAR_E2E_EXCLUDE_AXUM_IMPL;
             use crate::e2e::contexts::torrent::steps::upload_random_torrent_to_index;
             use crate::e2e::contexts::user::steps::{new_logged_in_admin, new_logged_in_user};
             use crate::e2e::environment::TestEnv;
@@ -1271,11 +1281,6 @@ mod with_axum_implementation {
             async fn it_should_allow_admins_to_delete_torrents_searching_by_info_hash() {
                 let mut env = TestEnv::new();
                 env.start(api::Implementation::Axum).await;
-
-                if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-                    println!("Skipped");
-                    return;
-                }
 
                 if !env.provides_a_tracker() {
                     println!("test skipped. It requires a tracker to be running.");
@@ -1300,11 +1305,6 @@ mod with_axum_implementation {
             async fn it_should_allow_admins_to_update_someone_elses_torrents() {
                 let mut env = TestEnv::new();
                 env.start(api::Implementation::Axum).await;
-
-                if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-                    println!("Skipped");
-                    return;
-                }
 
                 if !env.provides_a_tracker() {
                     println!("test skipped. It requires a tracker to be running.");

--- a/tests/e2e/contexts/user/contract.rs
+++ b/tests/e2e/contexts/user/contract.rs
@@ -1,4 +1,6 @@
 //! API contract for `user` context.
+use std::env;
+
 use torrust_index_backend::web::api;
 
 use crate::common::client::Client;
@@ -7,6 +9,7 @@ use crate::common::contexts::user::forms::{LoginForm, TokenRenewalForm, TokenVer
 use crate::common::contexts::user::responses::{
     SuccessfulLoginResponse, TokenRenewalData, TokenRenewalResponse, TokenVerifiedResponse,
 };
+use crate::e2e::config::ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL;
 use crate::e2e::contexts::user::steps::{new_logged_in_user, new_registered_user};
 use crate::e2e::environment::TestEnv;
 
@@ -42,6 +45,12 @@ the mailcatcher API.
 async fn it_should_allow_a_guest_user_to_register() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
+
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
+
     let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
     let form = random_user_registration_form();
@@ -59,6 +68,12 @@ async fn it_should_allow_a_guest_user_to_register() {
 async fn it_should_allow_a_registered_user_to_login() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
+
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
+
     let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
     let registered_user = new_registered_user(&env).await;
@@ -84,6 +99,12 @@ async fn it_should_allow_a_registered_user_to_login() {
 async fn it_should_allow_a_logged_in_user_to_verify_an_authentication_token() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
+
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
+
     let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
     let logged_in_user = new_logged_in_user(&env).await;
@@ -107,6 +128,11 @@ async fn it_should_allow_a_logged_in_user_to_verify_an_authentication_token() {
 async fn it_should_not_allow_a_logged_in_user_to_renew_an_authentication_token_which_is_still_valid_for_more_than_one_week() {
     let mut env = TestEnv::new();
     env.start(api::Implementation::ActixWeb).await;
+
+    if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+        println!("Skipped");
+        return;
+    }
 
     let logged_in_user = new_logged_in_user(&env).await;
     let client = Client::authenticated(&env.server_socket_addr().unwrap(), &logged_in_user.token);
@@ -134,11 +160,14 @@ async fn it_should_not_allow_a_logged_in_user_to_renew_an_authentication_token_w
 }
 
 mod banned_user_list {
+    use std::env;
+
     use torrust_index_backend::web::api;
 
     use crate::common::client::Client;
     use crate::common::contexts::user::forms::Username;
     use crate::common::contexts::user::responses::BannedUserResponse;
+    use crate::e2e::config::ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL;
     use crate::e2e::contexts::user::steps::{new_logged_in_admin, new_logged_in_user, new_registered_user};
     use crate::e2e::environment::TestEnv;
 
@@ -146,6 +175,11 @@ mod banned_user_list {
     async fn it_should_allow_an_admin_to_ban_a_user() {
         let mut env = TestEnv::new();
         env.start(api::Implementation::ActixWeb).await;
+
+        if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+            println!("Skipped");
+            return;
+        }
 
         let logged_in_admin = new_logged_in_admin(&env).await;
         let client = Client::authenticated(&env.server_socket_addr().unwrap(), &logged_in_admin.token);
@@ -168,6 +202,11 @@ mod banned_user_list {
         let mut env = TestEnv::new();
         env.start(api::Implementation::ActixWeb).await;
 
+        if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+            println!("Skipped");
+            return;
+        }
+
         let logged_non_admin = new_logged_in_user(&env).await;
         let client = Client::authenticated(&env.server_socket_addr().unwrap(), &logged_non_admin.token);
 
@@ -182,6 +221,12 @@ mod banned_user_list {
     async fn it_should_not_allow_a_guest_to_ban_a_user() {
         let mut env = TestEnv::new();
         env.start(api::Implementation::ActixWeb).await;
+
+        if env::var(ENV_VAR_E2E_EXCLUDE_ACTIX_WEB_IMPL).is_ok() {
+            println!("Skipped");
+            return;
+        }
+
         let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
         let registered_user = new_registered_user(&env).await;
@@ -195,25 +240,18 @@ mod banned_user_list {
 mod with_axum_implementation {
 
     mod registration {
-        use std::env;
 
         use torrust_index_backend::web::api;
 
         use crate::common::client::Client;
         use crate::common::contexts::user::asserts::assert_added_user_response;
         use crate::common::contexts::user::fixtures::random_user_registration_form;
-        use crate::e2e::config::ENV_VAR_E2E_EXCLUDE_AXUM_IMPL;
         use crate::e2e::environment::TestEnv;
 
         #[tokio::test]
         async fn it_should_allow_a_guest_user_to_register() {
             let mut env = TestEnv::new();
             env.start(api::Implementation::Axum).await;
-
-            if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-                println!("Skipped");
-                return;
-            }
 
             let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
@@ -226,7 +264,6 @@ mod with_axum_implementation {
     }
 
     mod authentication {
-        use std::env;
 
         use torrust_index_backend::web::api;
 
@@ -235,7 +272,6 @@ mod with_axum_implementation {
             assert_successful_login_response, assert_token_renewal_response, assert_token_verified_response,
         };
         use crate::common::contexts::user::forms::{LoginForm, TokenRenewalForm, TokenVerificationForm};
-        use crate::e2e::config::ENV_VAR_E2E_EXCLUDE_AXUM_IMPL;
         use crate::e2e::contexts::user::steps::{new_logged_in_user, new_registered_user};
         use crate::e2e::environment::TestEnv;
 
@@ -243,11 +279,6 @@ mod with_axum_implementation {
         async fn it_should_allow_a_registered_user_to_login() {
             let mut env = TestEnv::new();
             env.start(api::Implementation::Axum).await;
-
-            if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-                println!("Skipped");
-                return;
-            }
 
             let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
@@ -268,11 +299,6 @@ mod with_axum_implementation {
             let mut env = TestEnv::new();
             env.start(api::Implementation::Axum).await;
 
-            if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-                println!("Skipped");
-                return;
-            }
-
             let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
             let logged_in_user = new_logged_in_user(&env).await;
@@ -292,11 +318,6 @@ mod with_axum_implementation {
             let mut env = TestEnv::new();
             env.start(api::Implementation::Axum).await;
 
-            if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-                println!("Skipped");
-                return;
-            }
-
             let logged_in_user = new_logged_in_user(&env).await;
 
             let client = Client::authenticated(&env.server_socket_addr().unwrap(), &logged_in_user.token);
@@ -312,14 +333,12 @@ mod with_axum_implementation {
     }
 
     mod banned_user_list {
-        use std::env;
 
         use torrust_index_backend::web::api;
 
         use crate::common::client::Client;
         use crate::common::contexts::user::asserts::assert_banned_user_response;
         use crate::common::contexts::user::forms::Username;
-        use crate::e2e::config::ENV_VAR_E2E_EXCLUDE_AXUM_IMPL;
         use crate::e2e::contexts::user::steps::{new_logged_in_admin, new_logged_in_user, new_registered_user};
         use crate::e2e::environment::TestEnv;
 
@@ -327,11 +346,6 @@ mod with_axum_implementation {
         async fn it_should_allow_an_admin_to_ban_a_user() {
             let mut env = TestEnv::new();
             env.start(api::Implementation::Axum).await;
-
-            if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-                println!("Skipped");
-                return;
-            }
 
             let logged_in_admin = new_logged_in_admin(&env).await;
 
@@ -349,11 +363,6 @@ mod with_axum_implementation {
             let mut env = TestEnv::new();
             env.start(api::Implementation::Axum).await;
 
-            if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-                println!("Skipped");
-                return;
-            }
-
             let logged_non_admin = new_logged_in_user(&env).await;
 
             let client = Client::authenticated(&env.server_socket_addr().unwrap(), &logged_non_admin.token);
@@ -369,11 +378,6 @@ mod with_axum_implementation {
         async fn it_should_not_allow_a_guest_to_ban_a_user() {
             let mut env = TestEnv::new();
             env.start(api::Implementation::Axum).await;
-
-            if env::var(ENV_VAR_E2E_EXCLUDE_AXUM_IMPL).is_ok() {
-                println!("Skipped");
-                return;
-            }
 
             let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 


### PR DESCRIPTION
This makes the Axum implementation the default one for the API.