### PR TITLE
Add environment variable to set permissive CORS policy

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -12,6 +12,9 @@ pub const ENV_VAR_CONFIG: &str = "TORRUST_IDX_BACK_CONFIG";
 /// The `config.toml` file location.
 pub const ENV_VAR_CONFIG_PATH: &str = "TORRUST_IDX_BACK_CONFIG_PATH";
 
+/// If present, CORS will be permissive.
+pub const ENV_VAR_CORS_PERMISSIVE: &str = "TORRUST_IDX_BACK_CORS_PERMISSIVE";
+
 // Default values
 
 pub const ENV_VAR_DEFAULT_CONFIG_PATH: &str = "./config.toml";


### PR DESCRIPTION
Running the backend with:

```
TORRUST_IDX_BACK_CORS_PERMISSIVE=true cargo run
```

will make the CORS policy to be permissive, which means you can use a different port for the API and serving the frontend app. It's intented for development purposes.