### PR TITLE
Return 404 when torrent is not found

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -215,7 +215,7 @@ pub fn http_status_code_for_service_error(error: &ServiceError) -> StatusCode {
         ServiceError::TokenNotFound => StatusCode::UNAUTHORIZED,
         ServiceError::TokenExpired => StatusCode::UNAUTHORIZED,
         ServiceError::TokenInvalid => StatusCode::UNAUTHORIZED,
-        ServiceError::TorrentNotFound => StatusCode::BAD_REQUEST,
+        ServiceError::TorrentNotFound => StatusCode::NOT_FOUND,
         ServiceError::InvalidTorrentFile => StatusCode::BAD_REQUEST,
         ServiceError::InvalidTorrentPiecesLength => StatusCode::BAD_REQUEST,
         ServiceError::InvalidFileType => StatusCode::BAD_REQUEST,

--- a/tests/e2e/web/api/v1/contexts/torrent/contract.rs
+++ b/tests/e2e/web/api/v1/contexts/torrent/contract.rs
@@ -240,14 +240,23 @@ mod for_guests {
     }
 
     #[tokio::test]
-    async fn it_should_return_a_not_found_trying_to_download_a_non_existing_torrent() {
+    async fn it_should_return_a_not_found_response_trying_to_get_the_torrent_info_for_a_non_existing_torrent() {
         let mut env = TestEnv::new();
         env.start(api::Version::V1).await;
 
-        if !env.provides_a_tracker() {
-            println!("test skipped. It requires a tracker to be running.");
-            return;
-        }
+        let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
+
+        let non_existing_info_hash: InfoHash = "443c7602b4fde83d1154d6d9da48808418b181b6".to_string();
+
+        let response = client.get_torrent(&non_existing_info_hash).await;
+
+        assert_eq!(response.status, 404);
+    }
+
+    #[tokio::test]
+    async fn it_should_return_a_not_found_trying_to_download_a_non_existing_torrent() {
+        let mut env = TestEnv::new();
+        env.start(api::Version::V1).await;
 
         let client = Client::unauthenticated(&env.server_socket_addr().unwrap());
 
@@ -255,8 +264,7 @@ mod for_guests {
 
         let response = client.download_torrent(&non_existing_info_hash).await;
 
-        // code-review: should this be 404?
-        assert_eq!(response.status, 400);
+        assert_eq!(response.status, 404);
     }
 
     #[tokio::test]


### PR DESCRIPTION
The [endpoint to get the torrent info details](https://github.com/torrust/torrust-index-backend/blob/develop/src/web/api/v1/contexts/torrent/handlers.rs#L112-L128) returns a `404` HTTP status code instead of a `400` when the provided infohash does not exist in the database.

The [endpoint to download the torrent file](https://github.com/torrust/torrust-index-backend/blob/develop/src/web/api/v1/contexts/torrent/handlers.rs#L66-L86) is also changed.