### PR TITLE
Make torrent category optional

### DIFF
--- a/migrations/mysql/20230627103405_torrust_allow_null_categories.sql
+++ b/migrations/mysql/20230627103405_torrust_allow_null_categories.sql
@@ -1,0 +1,6 @@
+-- Step 1: Allow null categories for torrents
+ALTER TABLE torrust_torrents MODIFY category_id INTEGER NULL;
+
+-- Step 2: Set torrent category to NULL when category is deleted
+ALTER TABLE `torrust_torrents` DROP FOREIGN KEY `torrust_torrents_ibfk_2`;
+ALTER TABLE `torrust_torrents` ADD CONSTRAINT `torrust_torrents_ibfk_2` FOREIGN KEY (`category_id`) REFERENCES `torrust_categories` (`category_id`) ON DELETE SET NULL;

--- a/migrations/sqlite3/20230627103405_torrust_allow_null_categories.sql
+++ b/migrations/sqlite3/20230627103405_torrust_allow_null_categories.sql
@@ -1,0 +1,28 @@
+-- Step 1: Create a new table with the new structure
+CREATE TABLE IF NOT EXISTS "torrust_torrents_new" (
+	"torrent_id" INTEGER NOT NULL,
+	"uploader_id" INTEGER NOT NULL,
+	"category_id" INTEGER NULL,
+	"info_hash" TEXT NOT NULL UNIQUE,
+	"size" INTEGER NOT NULL,
+	"name" TEXT NOT NULL,
+	"pieces" TEXT NOT NULL,
+	"piece_length" INTEGER NOT NULL,
+	"private" BOOLEAN DEFAULT NULL,
+	"root_hash" INT NOT NULL DEFAULT 0,
+	"date_uploaded" TEXT NOT NULL,
+	FOREIGN KEY("uploader_id") REFERENCES "torrust_users"("user_id") ON DELETE CASCADE,
+	FOREIGN KEY("category_id") REFERENCES "torrust_categories"("category_id") ON DELETE SET NULL,
+	PRIMARY KEY("torrent_id" AUTOINCREMENT)
+);
+
+-- Step 2: Copy rows from the current table to the new table
+INSERT INTO torrust_torrents_new (torrent_id, uploader_id, category_id, info_hash, size, name, pieces, piece_length, private, root_hash, date_uploaded)
+SELECT torrent_id, uploader_id, category_id, info_hash, size, name, pieces, piece_length, private, root_hash, date_uploaded
+FROM torrust_torrents;
+
+-- Step 3: Delete the current table
+DROP TABLE torrust_torrents;
+
+-- Step 1: Rename the new table
+ALTER TABLE torrust_torrents_new RENAME TO torrust_torrents;

--- a/src/models/response.rs
+++ b/src/models/response.rs
@@ -52,7 +52,7 @@ pub struct TorrentResponse {
     pub info_hash: String,
     pub title: String,
     pub description: Option<String>,
-    pub category: Category,
+    pub category: Option<Category>,
     pub upload_date: String,
     pub file_size: i64,
     pub seeders: i64,
@@ -65,7 +65,7 @@ pub struct TorrentResponse {
 
 impl TorrentResponse {
     #[must_use]
-    pub fn from_listing(torrent_listing: TorrentListing, category: Category) -> TorrentResponse {
+    pub fn from_listing(torrent_listing: TorrentListing, category: Option<Category>) -> TorrentResponse {
         TorrentResponse {
             torrent_id: torrent_listing.torrent_id,
             uploader: torrent_listing.uploader,

--- a/src/models/torrent.rs
+++ b/src/models/torrent.rs
@@ -16,7 +16,7 @@ pub struct TorrentListing {
     pub info_hash: String,
     pub title: String,
     pub description: Option<String>,
-    pub category_id: i64,
+    pub category_id: Option<i64>,
     pub date_uploaded: String,
     pub file_size: i64,
     pub seeders: i64,

--- a/src/services/torrent.rs
+++ b/src/services/torrent.rs
@@ -221,7 +221,10 @@ impl Index {
 
         let torrent_id = torrent_listing.torrent_id;
 
-        let category = self.category_repository.get_by_id(&torrent_listing.category_id).await?;
+        let category = match torrent_listing.category_id {
+            Some(category_id) => Some(self.category_repository.get_by_id(&category_id).await?),
+            None => None,
+        };
 
         let mut torrent_response = TorrentResponse::from_listing(torrent_listing, category);
 
@@ -382,7 +385,10 @@ impl Index {
             .one_torrent_by_torrent_id(&torrent_listing.torrent_id)
             .await?;
 
-        let category = self.category_repository.get_by_id(&torrent_listing.category_id).await?;
+        let category = match torrent_listing.category_id {
+            Some(category_id) => Some(self.category_repository.get_by_id(&category_id).await?),
+            None => None,
+        };
 
         let torrent_response = TorrentResponse::from_listing(torrent_listing, category);
 


### PR DESCRIPTION
The JSON response can now contain a `null` value for the `category`:

```json
{
    "data": {
        "torrent_id": 1,
        "uploader": "josecelano",
        "info_hash": "E8564469C258B1373BC2D5749FB83B1BF83D68A0",
        "title": "Ubuntu",
        "description": null,
        "category": null,
        "upload_date": "2023-06-27 11:35:09",
        "file_size": 1261707713,
        "seeders": 0,
        "leechers": 0,
        "files": [
            {
                "path": [
                    "NNN.url"
                ],
                "length": 114,
                "md5sum": null
            },
            {
                "path": [
                    "XXX.url"
                ],
                "length": 121,
                "md5sum": null
            },
            {
                "path": [
                    "XXX.avi"
                ],
                "length": 1261707478,
                "md5sum": null
            }
        ],
        "trackers": [
            "udp://tracker:6969",
        ],
        "magnet_link": "magnet:?xt=urn:btih:E8564469C258B1373BC2D5749FB83B1BF83D68A0&dn=Ubuntu&tr=udp%3A%2F%2Ftracker%3A6969e",
        "tags": []
    }
}
```