### PR TITLE
Endpoint to create random torrents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3145,6 +3145,7 @@ dependencies = [
  "email_address",
  "fern",
  "futures",
+ "hex",
  "hyper",
  "indexmap 1.9.3",
  "jsonwebtoken",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,8 @@ axum = { version = "0.6.18", features = ["multipart"] }
 hyper = "0.14.26"
 tower-http = { version = "0.4.0", features = ["cors"] }
 email_address = "0.2.4"
+hex = "0.4.3"
+uuid = { version = "1.3", features = ["v4"] }
 
 [dev-dependencies]
 rand = "0.8"

--- a/src/models/info_hash.rs
+++ b/src/models/info_hash.rs
@@ -195,7 +195,7 @@ impl Ord for InfoHash {
 
 impl std::cmp::PartialOrd<InfoHash> for InfoHash {
     fn partial_cmp(&self, other: &InfoHash) -> Option<std::cmp::Ordering> {
-        self.0.partial_cmp(&other.0)
+        Some(self.cmp(other))
     }
 }
 

--- a/src/models/torrent_file.rs
+++ b/src/models/torrent_file.rs
@@ -103,31 +103,13 @@ pub struct Torrent {
 }
 
 impl Torrent {
-    #[must_use]
-    pub fn from_new_torrent_info_request(new_torrent_info: NewTorrentInfoRequest) -> Self {
-        let torrent_info = DbTorrentInfo {
-            torrent_id: 1,
-            info_hash: String::new(),
-            name: new_torrent_info.name,
-            pieces: new_torrent_info.pieces,
-            piece_length: 16384,
-            private: None,
-            root_hash: 0,
-        };
-        Torrent::from_db_info_files_and_announce_urls(torrent_info, new_torrent_info.files, new_torrent_info.announce_urls)
-    }
-
-    /// It hydrates a `Torrent` struct from the database data.
+    /// It builds a `Torrent` from a `NewTorrentInfoRequest`.
     ///
     /// # Panics
     ///
     /// This function will panic if the `torrent_info.pieces` is not a valid hex string.
     #[must_use]
-    pub fn from_db_info_files_and_announce_urls(
-        torrent_info: DbTorrentInfo,
-        torrent_files: Vec<TorrentFile>,
-        torrent_announce_urls: Vec<Vec<String>>,
-    ) -> Self {
+    pub fn from_new_torrent_info_request(torrent_info: NewTorrentInfoRequest) -> Self {
         let private = u8::try_from(torrent_info.private.unwrap_or(0)).ok();
 
         // the info part of the torrent file
@@ -152,8 +134,9 @@ impl Torrent {
         }
 
         // either set the single file or the multiple files information
-        if torrent_files.len() == 1 {
-            let torrent_file = torrent_files
+        if torrent_info.files.len() == 1 {
+            let torrent_file = torrent_info
+                .files
                 .first()
                 .expect("vector `torrent_files` should have at least one element");
 
@@ -175,7 +158,7 @@ impl Torrent {
 
             info.path = path;
         } else {
-            info.files = Some(torrent_files);
+            info.files = Some(torrent_info.files);
         }
 
         Self {
@@ -184,11 +167,30 @@ impl Torrent {
             nodes: None,
             encoding: None,
             httpseeds: None,
-            announce_list: Some(torrent_announce_urls),
+            announce_list: Some(torrent_info.announce_urls),
             creation_date: None,
             comment: None,
             created_by: None,
         }
+    }
+
+    /// It hydrates a `Torrent` struct from the database data.
+    #[must_use]
+    pub fn from_db_info_files_and_announce_urls(
+        torrent_info: DbTorrentInfo,
+        torrent_files: Vec<TorrentFile>,
+        torrent_announce_urls: Vec<Vec<String>>,
+    ) -> Self {
+        let torrent_info_request = NewTorrentInfoRequest {
+            name: torrent_info.name,
+            pieces: torrent_info.pieces,
+            piece_length: torrent_info.piece_length,
+            private: torrent_info.private,
+            root_hash: torrent_info.root_hash,
+            files: torrent_files,
+            announce_urls: torrent_announce_urls,
+        };
+        Torrent::from_new_torrent_info_request(torrent_info_request)
     }
 
     /// Sets the announce url to the tracker url and removes all other trackers

--- a/src/models/torrent_file.rs
+++ b/src/models/torrent_file.rs
@@ -4,6 +4,7 @@ use serde_bytes::ByteBuf;
 use sha1::{Digest, Sha1};
 
 use crate::config::Configuration;
+use crate::services::torrent_file::NewTorrentInfoRequest;
 use crate::utils::hex::{from_bytes, into_bytes};
 
 #[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
@@ -102,6 +103,20 @@ pub struct Torrent {
 }
 
 impl Torrent {
+    #[must_use]
+    pub fn from_new_torrent_info_request(new_torrent_info: NewTorrentInfoRequest) -> Self {
+        let torrent_info = DbTorrentInfo {
+            torrent_id: 1,
+            info_hash: String::new(),
+            name: new_torrent_info.name,
+            pieces: new_torrent_info.pieces,
+            piece_length: 16384,
+            private: None,
+            root_hash: 0,
+        };
+        Torrent::from_db_info_files_and_announce_urls(torrent_info, new_torrent_info.files, new_torrent_info.announce_urls)
+    }
+
     /// It hydrates a `Torrent` struct from the database data.
     ///
     /// # Panics

--- a/src/services/hasher.rs
+++ b/src/services/hasher.rs
@@ -1,0 +1,28 @@
+//! Hashing service
+use sha1::{Digest, Sha1};
+
+// Calculate the sha1 hash of a string
+#[must_use]
+pub fn sha1(data: &str) -> String {
+    // Create a Sha1 object
+    let mut hasher = Sha1::new();
+
+    // Write input message
+    hasher.update(data.as_bytes());
+
+    // Read hash digest and consume hasher
+    let result = hasher.finalize();
+
+    // Convert the hash (a byte array) to a string of hex characters
+    hex::encode(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::services::hasher::sha1;
+
+    #[test]
+    fn it_should_hash_an_string() {
+        assert_eq!(sha1("hello world"), "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed");
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -2,6 +2,7 @@
 pub mod about;
 pub mod authentication;
 pub mod category;
+pub mod hasher;
 pub mod proxy;
 pub mod settings;
 pub mod tag;

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -6,4 +6,5 @@ pub mod proxy;
 pub mod settings;
 pub mod tag;
 pub mod torrent;
+pub mod torrent_file;
 pub mod user;

--- a/src/services/torrent_file.rs
+++ b/src/services/torrent_file.rs
@@ -4,6 +4,10 @@ use uuid::Uuid;
 use crate::models::torrent_file::{Torrent, TorrentFile};
 use crate::services::hasher::sha1;
 
+/// It contains the information required to create a new torrent file.
+///
+/// It's not the full in-memory representation of a torrent file. The full
+/// in-memory representation is the `Torrent` struct.
 pub struct NewTorrentInfoRequest {
     pub name: String,
     pub pieces: String,

--- a/src/services/torrent_file.rs
+++ b/src/services/torrent_file.rs
@@ -1,8 +1,8 @@
 //! This module contains the services related to torrent file management.
-use sha1::{Digest, Sha1};
 use uuid::Uuid;
 
 use crate::models::torrent_file::{Torrent, TorrentFile};
+use crate::services::hasher::sha1;
 
 pub struct NewTorrentInfoRequest {
     pub name: String,
@@ -47,18 +47,4 @@ pub fn generate_random_torrent(id: Uuid) -> Torrent {
     };
 
     Torrent::from_new_torrent_info_request(torrent_info_request)
-}
-
-fn sha1(data: &str) -> String {
-    // Create a Sha1 object
-    let mut hasher = Sha1::new();
-
-    // Write input message
-    hasher.update(data.as_bytes());
-
-    // Read hash digest and consume hasher
-    let result = hasher.finalize();
-
-    // Convert the hash (a byte array) to a string of hex characters
-    hex::encode(result)
 }

--- a/src/services/torrent_file.rs
+++ b/src/services/torrent_file.rs
@@ -48,3 +48,45 @@ pub fn generate_random_torrent(id: Uuid) -> Torrent {
 
     Torrent::from_new_torrent_info_request(torrent_info_request)
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_bytes::ByteBuf;
+    use uuid::Uuid;
+
+    use crate::models::torrent_file::{Torrent, TorrentInfo};
+    use crate::services::torrent_file::generate_random_torrent;
+
+    #[test]
+    fn it_should_generate_a_random_meta_info_file() {
+        let uuid = Uuid::parse_str("d6170378-2c14-4ccc-870d-2a8e15195e23").unwrap();
+
+        let torrent = generate_random_torrent(uuid);
+
+        let expected_torrent = Torrent {
+            info: TorrentInfo {
+                name: "file-d6170378-2c14-4ccc-870d-2a8e15195e23.txt".to_string(),
+                pieces: Some(ByteBuf::from(vec![
+                    62, 231, 243, 51, 234, 165, 204, 209, 51, 132, 163, 133, 249, 50, 107, 46, 24, 15, 251, 32,
+                ])),
+                piece_length: 16384,
+                md5sum: None,
+                length: Some(37),
+                files: None,
+                private: Some(0),
+                path: None,
+                root_hash: None,
+            },
+            announce: None,
+            announce_list: Some(vec![]),
+            creation_date: None,
+            comment: None,
+            created_by: None,
+            nodes: None,
+            encoding: None,
+            httpseeds: None,
+        };
+
+        assert_eq!(torrent, expected_torrent);
+    }
+}

--- a/src/services/torrent_file.rs
+++ b/src/services/torrent_file.rs
@@ -1,0 +1,64 @@
+//! This module contains the services related to torrent file management.
+use sha1::{Digest, Sha1};
+use uuid::Uuid;
+
+use crate::models::torrent_file::{Torrent, TorrentFile};
+
+pub struct NewTorrentInfoRequest {
+    pub name: String,
+    pub pieces: String,
+    pub piece_length: i64,
+    pub private: Option<i64>,
+    pub root_hash: i64,
+    pub files: Vec<TorrentFile>,
+    pub announce_urls: Vec<Vec<String>>,
+}
+
+/// It generates a random single-file torrent for testing purposes.
+///
+/// The torrent will contain a single text file with the UUID as its content.
+///
+/// # Panics
+///
+/// This function will panic if the sample file contents length in bytes is
+/// greater than `i64::MAX`.
+#[must_use]
+pub fn generate_random_torrent(id: Uuid) -> Torrent {
+    // Content of the file from which the torrent will be generated.
+    // We use the UUID as the content of the file.
+    let file_contents = format!("{id}\n");
+
+    let torrent_files: Vec<TorrentFile> = vec![TorrentFile {
+        path: vec![String::new()],
+        length: i64::try_from(file_contents.len()).expect("file contents size in bytes cannot exceed i64::MAX"),
+        md5sum: None,
+    }];
+
+    let torrent_announce_urls: Vec<Vec<String>> = vec![];
+
+    let torrent_info_request = NewTorrentInfoRequest {
+        name: format!("file-{id}.txt"),
+        pieces: sha1(&file_contents),
+        piece_length: 16384,
+        private: None,
+        root_hash: 0,
+        files: torrent_files,
+        announce_urls: torrent_announce_urls,
+    };
+
+    Torrent::from_new_torrent_info_request(torrent_info_request)
+}
+
+fn sha1(data: &str) -> String {
+    // Create a Sha1 object
+    let mut hasher = Sha1::new();
+
+    // Write input message
+    hasher.update(data.as_bytes());
+
+    // Read hash digest and consume hasher
+    let result = hasher.finalize();
+
+    // Convert the hash (a byte array) to a string of hex characters
+    hex::encode(result)
+}

--- a/src/web/api/v1/contexts/torrent/handlers.rs
+++ b/src/web/api/v1/contexts/torrent/handlers.rs
@@ -309,7 +309,7 @@ async fn get_torrent_request_from_payload(mut payload: Multipart) -> Result<AddT
     let mut tags: Vec<TagId> = vec![];
 
     while let Some(mut field) = payload.next_field().await.unwrap() {
-        let name = field.name().unwrap().clone();
+        let name = field.name().unwrap();
 
         match name {
             "title" => {
@@ -342,7 +342,7 @@ async fn get_torrent_request_from_payload(mut payload: Multipart) -> Result<AddT
                 tags = serde_json::from_str(&string_data).map_err(|_| ServiceError::BadRequest)?;
             }
             "torrent" => {
-                let content_type = field.content_type().unwrap().clone();
+                let content_type = field.content_type().unwrap();
 
                 if content_type != "application/x-bittorrent" {
                     return Err(ServiceError::InvalidFileType);

--- a/src/web/api/v1/contexts/torrent/responses.rs
+++ b/src/web/api/v1/contexts/torrent/responses.rs
@@ -24,6 +24,14 @@ pub fn new_torrent_response(torrent_id: TorrentId, info_hash: &str) -> Json<OkRe
 }
 
 #[must_use]
-pub fn torrent_file_response(bytes: Vec<u8>) -> Response {
-    (StatusCode::OK, [(header::CONTENT_TYPE, "application/x-bittorrent")], bytes).into_response()
+pub fn torrent_file_response(bytes: Vec<u8>, filename: &str) -> Response {
+    (
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, "application/x-bittorrent"),
+            (header::CONTENT_DISPOSITION, &format!("attachment; filename={filename}")),
+        ],
+        bytes,
+    )
+        .into_response()
 }

--- a/src/web/api/v1/contexts/torrent/routes.rs
+++ b/src/web/api/v1/contexts/torrent/routes.rs
@@ -21,13 +21,18 @@ pub fn router_for_single_resources(app_data: Arc<AppData>) -> Router {
 
     Router::new()
         .route("/upload", post(upload_torrent_handler).with_state(app_data.clone()))
-        .route("/download/:info_hash", get(download_torrent_handler).with_state(app_data))
+        .route(
+            "/download/:info_hash",
+            get(download_torrent_handler).with_state(app_data.clone()),
+        )
+        .route(
+            "/meta-info/random/:uuid",
+            get(create_random_torrent_handler).with_state(app_data),
+        )
         .nest("/:info_hash", torrent_info_routes)
 }
 
 /// Routes for the [`torrent`](crate::web::api::v1::contexts::torrent) API context for multiple resources.
 pub fn router_for_multiple_resources(app_data: Arc<AppData>) -> Router {
-    Router::new()
-        .route("/", get(get_torrents_handler).with_state(app_data.clone()))
-        .route("/random", get(create_random_torrent_handler).with_state(app_data))
+    Router::new().route("/", get(get_torrents_handler).with_state(app_data))
 }

--- a/src/web/api/v1/contexts/torrent/routes.rs
+++ b/src/web/api/v1/contexts/torrent/routes.rs
@@ -7,8 +7,8 @@ use axum::routing::{delete, get, post, put};
 use axum::Router;
 
 use super::handlers::{
-    delete_torrent_handler, download_torrent_handler, get_torrent_info_handler, get_torrents_handler,
-    update_torrent_info_handler, upload_torrent_handler,
+    create_random_torrent_handler, delete_torrent_handler, download_torrent_handler, get_torrent_info_handler,
+    get_torrents_handler, update_torrent_info_handler, upload_torrent_handler,
 };
 use crate::common::AppData;
 
@@ -27,5 +27,7 @@ pub fn router_for_single_resources(app_data: Arc<AppData>) -> Router {
 
 /// Routes for the [`torrent`](crate::web::api::v1::contexts::torrent) API context for multiple resources.
 pub fn router_for_multiple_resources(app_data: Arc<AppData>) -> Router {
-    Router::new().route("/", get(get_torrents_handler).with_state(app_data))
+    Router::new()
+        .route("/", get(get_torrents_handler).with_state(app_data.clone()))
+        .route("/random", get(create_random_torrent_handler).with_state(app_data))
 }


### PR DESCRIPTION
Relates to: https://github.com/torrust/torrust-index-frontend/pull/185

Sometimes we need to generate a random torrent for testing purposes.

We need to generate test torrents for the frontend application. With this new endpoint, you can get a random torrent:

http://0.0.0.0:3001/v1/torrents/random

The torrent is a single-file torrent using a UUID for its name and the original data file contents.

In this repo, we use the `imdl` command to generate random torrents but in the frontend we are using cypress, and it seems the best option is [to make a request to an endpoint](https://docs.cypress.io/api/commands/request) to obtain dynamic fixtures like random (or customized in the future) torrents.

https://github.com/torrust/torrust-index-frontend/pull/185

### TODO

- [x] Generate the random ID
- [x] Calculate the correct value for the "pieces" field in the torrent file (sha1 hash of the contents).
- [x] Refactor: extract service. Remove the domain code from the handler.
- [ ] Refactor: add a new named the constructor for the `Torrent` instead of using the `from_db_info_files_and_announce_urls`. We do not need the `torrent_id`, for example.

Other things that we could implement:

- [ ] Add an env var to enable this endpoint only for development/testing environments.
- [x] Add an URL parameter with the UUDI: `v1/torrents/random/:uuid`. We use the UUID for the torrent name (torrent file name: `name.torrent`).
