### PR TITLE
Add minimum length in Torrent Title

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -94,6 +94,9 @@ pub enum ServiceError {
     #[display(fmt = "Only .torrent files can be uploaded.")]
     InvalidFileType,
 
+    #[display(fmt = "Torrent title is too short.")]
+    InvalidTorrentTitleLength,
+
     #[display(fmt = "Bad request.")]
     BadRequest,
 
@@ -219,6 +222,7 @@ pub fn http_status_code_for_service_error(error: &ServiceError) -> StatusCode {
         ServiceError::InvalidTorrentFile => StatusCode::BAD_REQUEST,
         ServiceError::InvalidTorrentPiecesLength => StatusCode::BAD_REQUEST,
         ServiceError::InvalidFileType => StatusCode::BAD_REQUEST,
+        &ServiceError::InvalidTorrentTitleLength => StatusCode::BAD_REQUEST,
         ServiceError::BadRequest => StatusCode::BAD_REQUEST,
         ServiceError::InvalidCategory => StatusCode::BAD_REQUEST,
         ServiceError::InvalidTag => StatusCode::BAD_REQUEST,

--- a/src/services/torrent.rs
+++ b/src/services/torrent.rs
@@ -105,7 +105,7 @@ impl Index {
         torrent_request.torrent.set_announce_urls(&self.configuration).await;
 
         if torrent_request.metadata.title.len() < 3 {
-            return Err(ServiceError::BadRequest);
+            return Err(ServiceError::InvalidTorrentTitleLength);
         }
 
         let category = self

--- a/src/services/torrent.rs
+++ b/src/services/torrent.rs
@@ -98,10 +98,15 @@ impl Index {
     /// * Unable to get the category from the database.
     /// * Unable to insert the torrent into the database.
     /// * Unable to add the torrent to the whitelist.
+    /// * Torrent title is too short.
     pub async fn add_torrent(&self, mut torrent_request: AddTorrentRequest, user_id: UserId) -> Result<TorrentId, ServiceError> {
         let _user = self.user_repository.get_compact(&user_id).await?;
 
         torrent_request.torrent.set_announce_urls(&self.configuration).await;
+
+        if torrent_request.metadata.title.len() < 3 {
+            return Err(ServiceError::BadRequest);
+        }
 
         let category = self
             .category_repository


### PR DESCRIPTION
 - Torrent title is checked that the title has at least 3 characters
 - If the title is smaller, a service error is issued