### PR TITLE
Add a custom header with info-hash to the download endpoints

### DIFF
--- a/src/services/torrent.rs
+++ b/src/services/torrent.rs
@@ -333,7 +333,6 @@ impl Index {
         let page_size = request.page_size.unwrap_or(default_torrent_page_size);
 
         // Guard that page size does not exceed the maximum
-        let max_torrent_page_size = max_torrent_page_size;
         let page_size = if page_size > max_torrent_page_size {
             max_torrent_page_size
         } else {

--- a/src/web/api/v1/contexts/torrent/handlers.rs
+++ b/src/web/api/v1/contexts/torrent/handlers.rs
@@ -94,7 +94,7 @@ pub async fn download_torrent_handler(
         return ServiceError::InternalServerError.into_response();
     };
 
-    torrent_file_response(bytes, &format!("{}.torrent", torrent.info.name))
+    torrent_file_response(bytes, &format!("{}.torrent", torrent.info.name), &torrent.info_hash())
 }
 
 /// It returns a list of torrents matching the search criteria.
@@ -244,7 +244,7 @@ pub async fn create_random_torrent_handler(State(_app_data): State<Arc<AppData>>
         return ServiceError::InternalServerError.into_response();
     };
 
-    torrent_file_response(bytes, &format!("{}.torrent", torrent.info.name))
+    torrent_file_response(bytes, &format!("{}.torrent", torrent.info.name), &torrent.info_hash())
 }
 
 /// Extracts the [`TorrentRequest`] from the multipart form payload.


### PR DESCRIPTION
Endpoints, where you can download a torrent file, have now a custom header containing the torrent infohash. The name of the header is: `x-torrust-torrent-infohash`.

It is added because [in the frontend we need the infohash in a cypress test](https://github.com/torrust/torrust-index-frontend/pull/185) and this way we do not need to parse the downloaded torrent which is faster and simpler.