### PR TITLE
Redirect to URL with canonical info-hash

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -12,7 +12,7 @@ use crate::services::authentication::{DbUserAuthenticationRepository, JsonWebTok
 use crate::services::category::{self, DbCategoryRepository};
 use crate::services::tag::{self, DbTagRepository};
 use crate::services::torrent::{
-    DbTorrentAnnounceUrlRepository, DbTorrentFileRepository, DbTorrentInfoHashRepository, DbTorrentInfoRepository,
+    DbCanonicalInfoHashGroupRepository, DbTorrentAnnounceUrlRepository, DbTorrentFileRepository, DbTorrentInfoRepository,
     DbTorrentListingGenerator, DbTorrentRepository, DbTorrentTagRepository,
 };
 use crate::services::user::{self, DbBannedUserList, DbUserProfileRepository, DbUserRepository};
@@ -68,7 +68,7 @@ pub async fn run(configuration: Configuration, api_version: &Version) -> Running
     let user_authentication_repository = Arc::new(DbUserAuthenticationRepository::new(database.clone()));
     let user_profile_repository = Arc::new(DbUserProfileRepository::new(database.clone()));
     let torrent_repository = Arc::new(DbTorrentRepository::new(database.clone()));
-    let torrent_info_hash_repository = Arc::new(DbTorrentInfoHashRepository::new(database.clone()));
+    let canonical_info_hash_group_repository = Arc::new(DbCanonicalInfoHashGroupRepository::new(database.clone()));
     let torrent_info_repository = Arc::new(DbTorrentInfoRepository::new(database.clone()));
     let torrent_file_repository = Arc::new(DbTorrentFileRepository::new(database.clone()));
     let torrent_announce_url_repository = Arc::new(DbTorrentAnnounceUrlRepository::new(database.clone()));
@@ -93,7 +93,7 @@ pub async fn run(configuration: Configuration, api_version: &Version) -> Running
         user_repository.clone(),
         category_repository.clone(),
         torrent_repository.clone(),
-        torrent_info_hash_repository.clone(),
+        canonical_info_hash_group_repository.clone(),
         torrent_info_repository.clone(),
         torrent_file_repository.clone(),
         torrent_announce_url_repository.clone(),
@@ -137,7 +137,7 @@ pub async fn run(configuration: Configuration, api_version: &Version) -> Running
         user_authentication_repository,
         user_profile_repository,
         torrent_repository,
-        torrent_info_hash_repository,
+        canonical_info_hash_group_repository,
         torrent_info_repository,
         torrent_file_repository,
         torrent_announce_url_repository,

--- a/src/common.rs
+++ b/src/common.rs
@@ -7,7 +7,7 @@ use crate::services::authentication::{DbUserAuthenticationRepository, JsonWebTok
 use crate::services::category::{self, DbCategoryRepository};
 use crate::services::tag::{self, DbTagRepository};
 use crate::services::torrent::{
-    DbTorrentAnnounceUrlRepository, DbTorrentFileRepository, DbTorrentInfoHashRepository, DbTorrentInfoRepository,
+    DbCanonicalInfoHashGroupRepository, DbTorrentAnnounceUrlRepository, DbTorrentFileRepository, DbTorrentInfoRepository,
     DbTorrentListingGenerator, DbTorrentRepository, DbTorrentTagRepository,
 };
 use crate::services::user::{self, DbBannedUserList, DbUserProfileRepository, DbUserRepository};
@@ -34,7 +34,7 @@ pub struct AppData {
     pub user_authentication_repository: Arc<DbUserAuthenticationRepository>,
     pub user_profile_repository: Arc<DbUserProfileRepository>,
     pub torrent_repository: Arc<DbTorrentRepository>,
-    pub torrent_info_hash_repository: Arc<DbTorrentInfoHashRepository>,
+    pub torrent_info_hash_repository: Arc<DbCanonicalInfoHashGroupRepository>,
     pub torrent_info_repository: Arc<DbTorrentInfoRepository>,
     pub torrent_file_repository: Arc<DbTorrentFileRepository>,
     pub torrent_announce_url_repository: Arc<DbTorrentAnnounceUrlRepository>,
@@ -70,7 +70,7 @@ impl AppData {
         user_authentication_repository: Arc<DbUserAuthenticationRepository>,
         user_profile_repository: Arc<DbUserProfileRepository>,
         torrent_repository: Arc<DbTorrentRepository>,
-        torrent_info_hash_repository: Arc<DbTorrentInfoHashRepository>,
+        torrent_info_hash_repository: Arc<DbCanonicalInfoHashGroupRepository>,
         torrent_info_repository: Arc<DbTorrentInfoRepository>,
         torrent_file_repository: Arc<DbTorrentFileRepository>,
         torrent_announce_url_repository: Arc<DbTorrentAnnounceUrlRepository>,

--- a/src/databases/database.rs
+++ b/src/databases/database.rs
@@ -12,7 +12,7 @@ use crate::models::torrent_file::{DbTorrentInfo, Torrent, TorrentFile};
 use crate::models::torrent_tag::{TagId, TorrentTag};
 use crate::models::tracker_key::TrackerKey;
 use crate::models::user::{User, UserAuthentication, UserCompact, UserId, UserProfile};
-use crate::services::torrent::OriginalInfoHashes;
+use crate::services::torrent::CanonicalInfoHashGroup;
 
 /// Database tables to be truncated when upgrading from v1.0.0 to v2.0.0.
 /// They must be in the correct order to avoid foreign key errors.
@@ -231,19 +231,30 @@ pub trait Database: Sync + Send {
         ))
     }
 
-    /// Returns the list of all infohashes producing the same canonical infohash.
-    ///
-    /// When you upload a torrent the infohash migth change because the Index
-    /// remove the non-standard fields in the `info` dictionary. That makes the
-    /// infohash change. The canonical infohash is the resulting infohash.
-    /// This function returns the original infohashes of a canonical infohash.
+    /// It returns the list of all infohashes producing the same canonical
+    /// infohash.
     ///
     /// If the original infohash was unknown, it returns the canonical infohash.
     ///
-    /// The relationship is 1 canonical infohash -> N original infohashes.
-    async fn get_torrent_canonical_info_hash_group(&self, canonical: &InfoHash) -> Result<OriginalInfoHashes, Error>;
+    /// # Errors
+    ///
+    /// Returns an error is there was a problem with the database.
+    async fn get_torrent_canonical_info_hash_group(&self, canonical: &InfoHash) -> Result<CanonicalInfoHashGroup, Error>;
 
-    async fn insert_torrent_info_hash(&self, original: &InfoHash, canonical: &InfoHash) -> Result<(), Error>;
+    /// It returns the [`CanonicalInfoHashGroup`] the info-hash belongs to, if
+    /// the info-hash belongs to a group. Otherwise, returns `None`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error is there was a problem with the database.
+    async fn find_canonical_info_hash_for(&self, info_hash: &InfoHash) -> Result<Option<InfoHash>, Error>;
+
+    /// It adds a new info-hash to the canonical info-hash group.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error is there was a problem with the database.
+    async fn add_info_hash_to_canonical_info_hash_group(&self, original: &InfoHash, canonical: &InfoHash) -> Result<(), Error>;
 
     /// Get torrent's info as `DbTorrentInfo` from `torrent_id`.
     async fn get_torrent_info_from_id(&self, torrent_id: i64) -> Result<DbTorrentInfo, Error>;

--- a/src/databases/mysql.rs
+++ b/src/databases/mysql.rs
@@ -17,7 +17,7 @@ use crate::models::torrent_file::{DbTorrentAnnounceUrl, DbTorrentFile, DbTorrent
 use crate::models::torrent_tag::{TagId, TorrentTag};
 use crate::models::tracker_key::TrackerKey;
 use crate::models::user::{User, UserAuthentication, UserCompact, UserId, UserProfile};
-use crate::services::torrent::{DbTorrentInfoHash, OriginalInfoHashes};
+use crate::services::torrent::{CanonicalInfoHashGroup, DbTorrentInfoHash};
 use crate::utils::clock;
 use crate::utils::hex::from_bytes;
 
@@ -590,7 +590,10 @@ impl Database for Mysql {
         }
     }
 
-    async fn get_torrent_canonical_info_hash_group(&self, canonical: &InfoHash) -> Result<OriginalInfoHashes, database::Error> {
+    async fn get_torrent_canonical_info_hash_group(
+        &self,
+        canonical: &InfoHash,
+    ) -> Result<CanonicalInfoHashGroup, database::Error> {
         let db_info_hashes = query_as::<_, DbTorrentInfoHash>(
             "SELECT info_hash, canonical_info_hash, original_is_known FROM torrust_torrent_info_hashes WHERE canonical_info_hash = ?",
         )
@@ -607,13 +610,35 @@ impl Database for Mysql {
             })
             .collect();
 
-        Ok(OriginalInfoHashes {
+        Ok(CanonicalInfoHashGroup {
             canonical_info_hash: *canonical,
             original_info_hashes: info_hashes,
         })
     }
 
-    async fn insert_torrent_info_hash(&self, info_hash: &InfoHash, canonical: &InfoHash) -> Result<(), database::Error> {
+    async fn find_canonical_info_hash_for(&self, info_hash: &InfoHash) -> Result<Option<InfoHash>, database::Error> {
+        let maybe_db_torrent_info_hash = query_as::<_, DbTorrentInfoHash>(
+            "SELECT info_hash, canonical_info_hash, original_is_known FROM torrust_torrent_info_hashes WHERE info_hash = ?",
+        )
+        .bind(info_hash.to_hex_string())
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|err| database::Error::ErrorWithText(err.to_string()))?;
+
+        match maybe_db_torrent_info_hash {
+            Some(db_torrent_info_hash) => Ok(Some(
+                InfoHash::from_str(&db_torrent_info_hash.canonical_info_hash)
+                    .unwrap_or_else(|_| panic!("Invalid info-hash in database: {}", db_torrent_info_hash.canonical_info_hash)),
+            )),
+            None => Ok(None),
+        }
+    }
+
+    async fn add_info_hash_to_canonical_info_hash_group(
+        &self,
+        info_hash: &InfoHash,
+        canonical: &InfoHash,
+    ) -> Result<(), database::Error> {
         query("INSERT INTO torrust_torrent_info_hashes (info_hash, canonical_info_hash, original_is_known) VALUES (?, ?, ?)")
             .bind(info_hash.to_hex_string())
             .bind(canonical.to_hex_string())

--- a/src/web/api/v1/contexts/torrent/handlers.rs
+++ b/src/web/api/v1/contexts/torrent/handlers.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use axum::extract::{self, Multipart, Path, Query, State};
-use axum::response::{IntoResponse, Response};
+use axum::response::{IntoResponse, Redirect, Response};
 use axum::Json;
 use serde::Deserialize;
 use uuid::Uuid;
@@ -78,21 +78,25 @@ pub async fn download_torrent_handler(
         return errors::Request::InvalidInfoHashParam.into_response();
     };
 
-    let opt_user_id = match get_optional_logged_in_user(maybe_bearer_token, app_data.clone()).await {
-        Ok(opt_user_id) => opt_user_id,
-        Err(error) => return error.into_response(),
-    };
+    if let Some(redirect_response) = guard_that_canonical_info_hash_is_used_or_redirect(&app_data, &info_hash).await {
+        redirect_response
+    } else {
+        let opt_user_id = match get_optional_logged_in_user(maybe_bearer_token, app_data.clone()).await {
+            Ok(opt_user_id) => opt_user_id,
+            Err(error) => return error.into_response(),
+        };
 
-    let torrent = match app_data.torrent_service.get_torrent(&info_hash, opt_user_id).await {
-        Ok(torrent) => torrent,
-        Err(error) => return error.into_response(),
-    };
+        let torrent = match app_data.torrent_service.get_torrent(&info_hash, opt_user_id).await {
+            Ok(torrent) => torrent,
+            Err(error) => return error.into_response(),
+        };
 
-    let Ok(bytes) = parse_torrent::encode_torrent(&torrent) else {
-        return ServiceError::InternalServerError.into_response();
-    };
+        let Ok(bytes) = parse_torrent::encode_torrent(&torrent) else {
+            return ServiceError::InternalServerError.into_response();
+        };
 
-    torrent_file_response(bytes, &format!("{}.torrent", torrent.info.name), &torrent.info_hash_hex())
+        torrent_file_response(bytes, &format!("{}.torrent", torrent.info.name), &torrent.info_hash_hex())
+    }
 }
 
 /// It returns a list of torrents matching the search criteria.
@@ -128,14 +132,37 @@ pub async fn get_torrent_info_handler(
         return errors::Request::InvalidInfoHashParam.into_response();
     };
 
-    let opt_user_id = match get_optional_logged_in_user(maybe_bearer_token, app_data.clone()).await {
-        Ok(opt_user_id) => opt_user_id,
-        Err(error) => return error.into_response(),
-    };
+    if let Some(redirect_response) = guard_that_canonical_info_hash_is_used_or_redirect(&app_data, &info_hash).await {
+        redirect_response
+    } else {
+        let opt_user_id = match get_optional_logged_in_user(maybe_bearer_token, app_data.clone()).await {
+            Ok(opt_user_id) => opt_user_id,
+            Err(error) => return error.into_response(),
+        };
 
-    match app_data.torrent_service.get_torrent_info(&info_hash, opt_user_id).await {
-        Ok(torrent_response) => Json(OkResponseData { data: torrent_response }).into_response(),
-        Err(error) => error.into_response(),
+        match app_data.torrent_service.get_torrent_info(&info_hash, opt_user_id).await {
+            Ok(torrent_response) => Json(OkResponseData { data: torrent_response }).into_response(),
+            Err(error) => error.into_response(),
+        }
+    }
+}
+
+async fn guard_that_canonical_info_hash_is_used_or_redirect(app_data: &Arc<AppData>, info_hash: &InfoHash) -> Option<Response> {
+    match app_data
+        .torrent_info_hash_repository
+        .find_canonical_info_hash_for(info_hash)
+        .await
+    {
+        Ok(Some(canonical_info_hash)) => {
+            if canonical_info_hash != *info_hash {
+                return Some(
+                    Redirect::temporary(&format!("/v1/torrent/{}", canonical_info_hash.to_hex_string())).into_response(),
+                );
+            }
+            None
+        }
+        Ok(None) => None,
+        Err(error) => Some(error.into_response()),
     }
 }
 

--- a/tests/common/client.rs
+++ b/tests/common/client.rs
@@ -208,6 +208,10 @@ impl Http {
                 .await
                 .unwrap(),
         };
+        // todo: If the response is a JSON, it returns the JSON body in a byte
+        //   array. This is not the expected behavior.
+        //  - Rename BinaryResponse to BinaryTorrentResponse
+        //  - Return an error if the response is not a bittorrent file
         BinaryResponse::from(response).await
     }
 

--- a/tests/common/contexts/torrent/fixtures.rs
+++ b/tests/common/contexts/torrent/fixtures.rs
@@ -137,7 +137,7 @@ impl TestTorrent {
         }
     }
 
-    pub fn info_hash_as_hex_string(&self) -> InfoHash {
+    pub fn file_info_hash(&self) -> InfoHash {
         self.file_info.info_hash.clone()
     }
 }

--- a/tests/e2e/web/api/v1/contexts/torrent/steps.rs
+++ b/tests/e2e/web/api/v1/contexts/torrent/steps.rs
@@ -1,3 +1,8 @@
+use std::str::FromStr;
+
+use torrust_index_backend::models::info_hash::InfoHash;
+use torrust_index_backend::web::api::v1::responses::ErrorResponseData;
+
 use crate::common::client::Client;
 use crate::common::contexts::torrent::fixtures::{random_torrent, TestTorrent, TorrentIndexInfo, TorrentListedInIndex};
 use crate::common::contexts::torrent::forms::UploadTorrentMultipartForm;
@@ -27,4 +32,28 @@ pub async fn upload_torrent(uploader: &LoggedInUserData, torrent: &TorrentIndexI
     }
 
     TorrentListedInIndex::from(torrent.clone(), res.unwrap().data.torrent_id)
+}
+
+/// Upload a torrent to the index.
+///
+/// # Errors
+///
+/// Returns an `ErrorResponseData` if the response is not a 200.
+pub async fn upload_test_torrent(client: &Client, test_torrent: &TestTorrent) -> Result<InfoHash, ErrorResponseData> {
+    let form: UploadTorrentMultipartForm = test_torrent.clone().index_info.into();
+    let response = client.upload_torrent(form.into()).await;
+
+    if response.status != 200 {
+        let error: ErrorResponseData = serde_json::from_str(&response.body)
+            .unwrap_or_else(|_| panic!("response {:#?} should be a ErrorResponseData", response.body));
+        return Err(error);
+    }
+
+    let uploaded_torrent_response: UploadedTorrentResponse = serde_json::from_str(&response.body).unwrap();
+    let canonical_info_hash_hex = uploaded_torrent_response.data.info_hash.to_lowercase();
+
+    let canonical_info_hash = InfoHash::from_str(&canonical_info_hash_hex)
+        .unwrap_or_else(|_| panic!("Invalid info-hash in database: {canonical_info_hash_hex}"));
+
+    Ok(canonical_info_hash)
 }


### PR DESCRIPTION
For endpoints using a GET param with an infohash:

- `GET /v1/torrent/INFO_HASH`
- `GET /v1/torrent/download/INFO_HASH`

That param must be the canonical infohash so far. This PR allows users to use the original info-hash.

Suppose the URL contains an info-hash, which is not canonical but belongs to a canonical info-hash group. In that case, the response will be a redirection (307) to the same URL but using the canonical info-hash.

### Subtasks

- [x] Refactor: use the new domain concept `Canonical Infohash Group`.
- [x] Add the redirection.
- [x] Add test for torrent details URL redirection.
- [x] Add test for download torrent URL redirection.

