### PR TITLE
Add tags to torrent details in test responses

### DIFF
--- a/tests/common/contexts/category/fixtures.rs
+++ b/tests/common/contexts/category/fixtures.rs
@@ -1,6 +1,6 @@
 use rand::Rng;
 
-pub fn software_predefined_category_name() -> String {
+pub fn software_category_name() -> String {
     "software".to_string()
 }
 

--- a/tests/common/contexts/torrent/asserts.rs
+++ b/tests/common/contexts/torrent/asserts.rs
@@ -1,37 +1,42 @@
 use super::responses::TorrentDetails;
 
+type Check = (&'static str, bool);
+
 /// Assert that the torrent details match the expected ones.
+///
 /// It ignores some fields that are not relevant for the E2E tests
 /// or hard to assert due to the concurrent nature of the tests.
 pub fn assert_expected_torrent_details(torrent: &TorrentDetails, expected_torrent: &TorrentDetails) {
-    assert_eq!(
-        torrent.torrent_id, expected_torrent.torrent_id,
-        "torrent `file_size` mismatch"
-    );
-    assert_eq!(torrent.uploader, expected_torrent.uploader, "torrent `uploader` mismatch");
-    assert_eq!(torrent.info_hash, expected_torrent.info_hash, "torrent `info_hash` mismatch");
-    assert_eq!(torrent.title, expected_torrent.title, "torrent `title` mismatch");
-    assert_eq!(
-        torrent.description, expected_torrent.description,
-        "torrent `description` mismatch"
-    );
-    assert_eq!(
-        torrent.category.category_id, expected_torrent.category.category_id,
-        "torrent `category.category_id` mismatch"
-    );
-    assert_eq!(
-        torrent.category.name, expected_torrent.category.name,
-        "torrent `category.name` mismatch"
-    );
-    // assert_eq!(torrent.category.num_torrents, expected_torrent.category.num_torrents, "torrent `category.num_torrents` mismatch"); // Ignored
-    // assert_eq!(torrent.upload_date, expected_torrent.upload_date, "torrent `upload_date` mismatch"); // Ignored, can't mock time easily for now.
-    assert_eq!(torrent.file_size, expected_torrent.file_size, "torrent `file_size` mismatch");
-    assert_eq!(torrent.seeders, expected_torrent.seeders, "torrent `seeders` mismatch");
-    assert_eq!(torrent.leechers, expected_torrent.leechers, "torrent `leechers` mismatch");
-    assert_eq!(torrent.files, expected_torrent.files, "torrent `files` mismatch");
-    assert_eq!(torrent.trackers, expected_torrent.trackers, "torrent `trackers` mismatch");
-    assert_eq!(
-        torrent.magnet_link, expected_torrent.magnet_link,
-        "torrent `magnet_link` mismatch"
-    );
+    let mut discrepancies = Vec::new();
+
+    let checks: Vec<Check> = vec![
+        ("torrent_id", torrent.torrent_id == expected_torrent.torrent_id),
+        ("uploader", torrent.uploader == expected_torrent.uploader),
+        ("info_hash", torrent.info_hash == expected_torrent.info_hash),
+        ("title", torrent.title == expected_torrent.title),
+        ("description", torrent.description == expected_torrent.description),
+        (
+            "category.category_id",
+            torrent.category.category_id == expected_torrent.category.category_id,
+        ),
+        ("category.name", torrent.category.name == expected_torrent.category.name),
+        ("file_size", torrent.file_size == expected_torrent.file_size),
+        ("seeders", torrent.seeders == expected_torrent.seeders),
+        ("leechers", torrent.leechers == expected_torrent.leechers),
+        ("files", torrent.files == expected_torrent.files),
+        ("trackers", torrent.trackers == expected_torrent.trackers),
+        ("magnet_link", torrent.magnet_link == expected_torrent.magnet_link),
+        ("tags", torrent.tags == expected_torrent.tags),
+        ("name", torrent.name == expected_torrent.name),
+    ];
+
+    for (field_name, equals) in &checks {
+        if !equals {
+            discrepancies.push((*field_name).to_string());
+        }
+    }
+
+    let error_message = format!("left:\n{torrent:#?}\nright:\n{expected_torrent:#?}\ndiscrepancies: {discrepancies:#?}");
+
+    assert!(discrepancies.is_empty(), "{}", error_message);
 }

--- a/tests/common/contexts/torrent/responses.rs
+++ b/tests/common/contexts/torrent/responses.rs
@@ -2,6 +2,7 @@ use serde::Deserialize;
 
 pub type Id = i64;
 pub type CategoryId = i64;
+pub type TagId = i64;
 pub type UtcDateTime = String; // %Y-%m-%d %H:%M:%S
 
 #[derive(Deserialize, PartialEq, Debug)]
@@ -61,6 +62,7 @@ pub struct TorrentDetails {
     pub files: Vec<File>,
     pub trackers: Vec<String>,
     pub magnet_link: String,
+    pub tags: Vec<Tag>,
     pub name: String,
 }
 
@@ -69,6 +71,12 @@ pub struct Category {
     pub category_id: CategoryId,
     pub name: String,
     pub num_torrents: u64,
+}
+
+#[derive(Deserialize, PartialEq, Debug)]
+pub struct Tag {
+    pub tag_id: TagId,
+    pub name: String,
 }
 
 #[derive(Deserialize, PartialEq, Debug)]

--- a/tests/e2e/web/api/v1/contexts/torrent/contract.rs
+++ b/tests/e2e/web/api/v1/contexts/torrent/contract.rs
@@ -209,6 +209,7 @@ mod for_guests {
                 encoded_tracker_url,
                 encoded_tracker_url
             ),
+            tags: vec![],
             name: test_torrent.index_info.name.clone(),
         };
 


### PR DESCRIPTION
In the **tests** the struct:

```rust
pub struct TorrentDetails {
    pub torrent_id: Id,
    pub uploader: String,
    pub info_hash: String,
    pub title: String,
    pub description: String,
    pub category: Category,
    pub upload_date: UtcDateTime,
    pub file_size: u64,
    pub seeders: u64,
    pub leechers: u64,
    pub files: Vec<File>,
    pub trackers: Vec<String>,
    pub magnet_link: String,
}
```

did not contain the torrent tags, so tests were not asserting that the tags were the expected ones.