### PR TITLE
Persist torrent `comment`

### DIFF
--- a/migrations/mysql/20230918103654_torrust_add_comment_field_to_torrent.sql
+++ b/migrations/mysql/20230918103654_torrust_add_comment_field_to_torrent.sql
@@ -1,0 +1,1 @@
+ALTER TABLE torrust_torrents ADD COLUMN comment TEXT NULL;

--- a/migrations/sqlite3/20230918103654_torrust_add_comment_field_to_torrent.sql
+++ b/migrations/sqlite3/20230918103654_torrust_add_comment_field_to_torrent.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "torrust_torrents" ADD COLUMN "comment" TEXT NULL;

--- a/src/databases/database.rs
+++ b/src/databases/database.rs
@@ -209,7 +209,7 @@ pub trait Database: Sync + Send {
 
         let torrent_announce_urls = self.get_torrent_announce_urls_from_id(torrent_info.torrent_id).await?;
 
-        Ok(Torrent::from_database(torrent_info, torrent_files, torrent_announce_urls))
+        Ok(Torrent::from_database(&torrent_info, &torrent_files, torrent_announce_urls))
     }
 
     /// Get `Torrent` from `torrent_id`.
@@ -220,7 +220,7 @@ pub trait Database: Sync + Send {
 
         let torrent_announce_urls = self.get_torrent_announce_urls_from_id(torrent_id).await?;
 
-        Ok(Torrent::from_database(torrent_info, torrent_files, torrent_announce_urls))
+        Ok(Torrent::from_database(&torrent_info, &torrent_files, torrent_announce_urls))
     }
 
     /// It returns the list of all infohashes producing the same canonical

--- a/src/databases/database.rs
+++ b/src/databases/database.rs
@@ -203,24 +203,24 @@ pub trait Database: Sync + Send {
 
     /// Get `Torrent` from `InfoHash`.
     async fn get_torrent_from_info_hash(&self, info_hash: &InfoHash) -> Result<Torrent, Error> {
-        let torrent_info = self.get_torrent_info_from_info_hash(info_hash).await?;
+        let db_torrent = self.get_torrent_info_from_info_hash(info_hash).await?;
 
-        let torrent_files = self.get_torrent_files_from_id(torrent_info.torrent_id).await?;
+        let torrent_files = self.get_torrent_files_from_id(db_torrent.torrent_id).await?;
 
-        let torrent_announce_urls = self.get_torrent_announce_urls_from_id(torrent_info.torrent_id).await?;
+        let torrent_announce_urls = self.get_torrent_announce_urls_from_id(db_torrent.torrent_id).await?;
 
-        Ok(Torrent::from_database(&torrent_info, &torrent_files, torrent_announce_urls))
+        Ok(Torrent::from_database(&db_torrent, &torrent_files, torrent_announce_urls))
     }
 
     /// Get `Torrent` from `torrent_id`.
     async fn get_torrent_from_id(&self, torrent_id: i64) -> Result<Torrent, Error> {
-        let torrent_info = self.get_torrent_info_from_id(torrent_id).await?;
+        let db_torrent = self.get_torrent_info_from_id(torrent_id).await?;
 
         let torrent_files = self.get_torrent_files_from_id(torrent_id).await?;
 
         let torrent_announce_urls = self.get_torrent_announce_urls_from_id(torrent_id).await?;
 
-        Ok(Torrent::from_database(&torrent_info, &torrent_files, torrent_announce_urls))
+        Ok(Torrent::from_database(&db_torrent, &torrent_files, torrent_announce_urls))
     }
 
     /// It returns the list of all infohashes producing the same canonical

--- a/src/databases/database.rs
+++ b/src/databases/database.rs
@@ -8,7 +8,7 @@ use crate::models::category::CategoryId;
 use crate::models::info_hash::InfoHash;
 use crate::models::response::TorrentsResponse;
 use crate::models::torrent::TorrentListing;
-use crate::models::torrent_file::{DbTorrentInfo, Torrent, TorrentFile};
+use crate::models::torrent_file::{DbTorrent, Torrent, TorrentFile};
 use crate::models::torrent_tag::{TagId, TorrentTag};
 use crate::models::tracker_key::TrackerKey;
 use crate::models::user::{User, UserAuthentication, UserCompact, UserId, UserProfile};
@@ -209,11 +209,7 @@ pub trait Database: Sync + Send {
 
         let torrent_announce_urls = self.get_torrent_announce_urls_from_id(torrent_info.torrent_id).await?;
 
-        Ok(Torrent::from_db_info_files_and_announce_urls(
-            torrent_info,
-            torrent_files,
-            torrent_announce_urls,
-        ))
+        Ok(Torrent::from_database(torrent_info, torrent_files, torrent_announce_urls))
     }
 
     /// Get `Torrent` from `torrent_id`.
@@ -224,11 +220,7 @@ pub trait Database: Sync + Send {
 
         let torrent_announce_urls = self.get_torrent_announce_urls_from_id(torrent_id).await?;
 
-        Ok(Torrent::from_db_info_files_and_announce_urls(
-            torrent_info,
-            torrent_files,
-            torrent_announce_urls,
-        ))
+        Ok(Torrent::from_database(torrent_info, torrent_files, torrent_announce_urls))
     }
 
     /// It returns the list of all infohashes producing the same canonical
@@ -257,10 +249,10 @@ pub trait Database: Sync + Send {
     async fn add_info_hash_to_canonical_info_hash_group(&self, original: &InfoHash, canonical: &InfoHash) -> Result<(), Error>;
 
     /// Get torrent's info as `DbTorrentInfo` from `torrent_id`.
-    async fn get_torrent_info_from_id(&self, torrent_id: i64) -> Result<DbTorrentInfo, Error>;
+    async fn get_torrent_info_from_id(&self, torrent_id: i64) -> Result<DbTorrent, Error>;
 
     /// Get torrent's info as `DbTorrentInfo` from torrent `InfoHash`.
-    async fn get_torrent_info_from_info_hash(&self, info_hash: &InfoHash) -> Result<DbTorrentInfo, Error>;
+    async fn get_torrent_info_from_info_hash(&self, info_hash: &InfoHash) -> Result<DbTorrent, Error>;
 
     /// Get all torrent's files as `Vec<TorrentFile>` from `torrent_id`.
     async fn get_torrent_files_from_id(&self, torrent_id: i64) -> Result<Vec<TorrentFile>, Error>;

--- a/src/databases/mysql.rs
+++ b/src/databases/mysql.rs
@@ -13,7 +13,7 @@ use crate::models::category::CategoryId;
 use crate::models::info_hash::InfoHash;
 use crate::models::response::TorrentsResponse;
 use crate::models::torrent::TorrentListing;
-use crate::models::torrent_file::{DbTorrentAnnounceUrl, DbTorrentFile, DbTorrentInfo, Torrent, TorrentFile};
+use crate::models::torrent_file::{DbTorrent, DbTorrentAnnounceUrl, DbTorrentFile, Torrent, TorrentFile};
 use crate::models::torrent_tag::{TagId, TorrentTag};
 use crate::models::tracker_key::TrackerKey;
 use crate::models::user::{User, UserAuthentication, UserCompact, UserId, UserProfile};
@@ -676,16 +676,16 @@ impl Database for Mysql {
             .map_err(|err| database::Error::ErrorWithText(err.to_string()))
     }
 
-    async fn get_torrent_info_from_id(&self, torrent_id: i64) -> Result<DbTorrentInfo, database::Error> {
-        query_as::<_, DbTorrentInfo>("SELECT * FROM torrust_torrents WHERE torrent_id = ?")
+    async fn get_torrent_info_from_id(&self, torrent_id: i64) -> Result<DbTorrent, database::Error> {
+        query_as::<_, DbTorrent>("SELECT * FROM torrust_torrents WHERE torrent_id = ?")
             .bind(torrent_id)
             .fetch_one(&self.pool)
             .await
             .map_err(|_| database::Error::TorrentNotFound)
     }
 
-    async fn get_torrent_info_from_info_hash(&self, info_hash: &InfoHash) -> Result<DbTorrentInfo, database::Error> {
-        query_as::<_, DbTorrentInfo>("SELECT * FROM torrust_torrents WHERE info_hash = ?")
+    async fn get_torrent_info_from_info_hash(&self, info_hash: &InfoHash) -> Result<DbTorrent, database::Error> {
+        query_as::<_, DbTorrent>("SELECT * FROM torrust_torrents WHERE info_hash = ?")
             .bind(info_hash.to_hex_string().to_lowercase())
             .fetch_one(&self.pool)
             .await

--- a/src/databases/sqlite.rs
+++ b/src/databases/sqlite.rs
@@ -290,7 +290,8 @@ impl Database for Sqlite {
             })
     }
 
-    // TODO: refactor this
+    // todo: refactor this
+    #[allow(clippy::too_many_lines)]
     async fn get_torrents_search_sorted_paginated(
         &self,
         search: &Option<String>,
@@ -365,7 +366,17 @@ impl Database for Sqlite {
         };
 
         let mut query_string = format!(
-            "SELECT tt.torrent_id, tp.username AS uploader, tt.info_hash, ti.title, ti.description, tt.category_id, tt.date_uploaded, tt.size AS file_size, tt.name, 
+            "SELECT
+            tt.torrent_id,
+            tp.username AS uploader,
+            tt.info_hash,
+            ti.title,
+            ti.description,
+            tt.category_id,
+            tt.date_uploaded,
+            tt.size AS file_size,
+            tt.name,
+            tt.comment,
             CAST(COALESCE(sum(ts.seeders),0) as signed) as seeders,
             CAST(COALESCE(sum(ts.leechers),0) as signed) as leechers
             FROM torrust_torrents tt
@@ -433,31 +444,47 @@ impl Database for Sqlite {
         };
 
         // add torrent
-        let torrent_id = query("INSERT INTO torrust_torrents (uploader_id, category_id, info_hash, size, name, pieces, piece_length, private, root_hash, `source`, date_uploaded) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%d %H:%M:%S',DATETIME('now', 'utc')))")
-            .bind(uploader_id)
-            .bind(category_id)
-            .bind(info_hash.to_lowercase())
-            .bind(torrent.file_size())
-            .bind(torrent.info.name.to_string())
-            .bind(pieces)
-            .bind(torrent.info.piece_length)
-            .bind(torrent.info.private)
-            .bind(root_hash)
-            .bind(torrent.info.source.clone())
-            .execute(&mut tx)
-            .await
-            .map(|v| v.last_insert_rowid())
-            .map_err(|e| match e {
-                sqlx::Error::Database(err) => {
-                    log::error!("DB error: {:?}", err);
-                    if err.message().contains("UNIQUE") && err.message().contains("info_hash") {
-                        database::Error::TorrentAlreadyExists
-                    } else {
-                        database::Error::Error
-                    }
+        let torrent_id = query(
+            "INSERT INTO torrust_torrents (
+            uploader_id,
+            category_id,
+            info_hash,
+            size,
+            name,
+            pieces,
+            piece_length,
+            private,
+            root_hash,
+            `source`,
+            comment,
+            date_uploaded
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%d %H:%M:%S',DATETIME('now', 'utc')))",
+        )
+        .bind(uploader_id)
+        .bind(category_id)
+        .bind(info_hash.to_lowercase())
+        .bind(torrent.file_size())
+        .bind(torrent.info.name.to_string())
+        .bind(pieces)
+        .bind(torrent.info.piece_length)
+        .bind(torrent.info.private)
+        .bind(root_hash)
+        .bind(torrent.info.source.clone())
+        .bind(torrent.comment.clone())
+        .execute(&mut tx)
+        .await
+        .map(|v| v.last_insert_rowid())
+        .map_err(|e| match e {
+            sqlx::Error::Database(err) => {
+                log::error!("DB error: {:?}", err);
+                if err.message().contains("UNIQUE") && err.message().contains("info_hash") {
+                    database::Error::TorrentAlreadyExists
+                } else {
+                    database::Error::Error
                 }
-                _ => database::Error::Error
-            })?;
+            }
+            _ => database::Error::Error,
+        })?;
 
         // add torrent canonical infohash
 
@@ -640,23 +667,19 @@ impl Database for Sqlite {
     }
 
     async fn get_torrent_info_from_id(&self, torrent_id: i64) -> Result<DbTorrentInfo, database::Error> {
-        query_as::<_, DbTorrentInfo>(
-            "SELECT torrent_id, info_hash, name, pieces, piece_length, private, root_hash FROM torrust_torrents WHERE torrent_id = ?",
-        )
-        .bind(torrent_id)
-        .fetch_one(&self.pool)
-        .await
-        .map_err(|_| database::Error::TorrentNotFound)
+        query_as::<_, DbTorrentInfo>("SELECT * FROM torrust_torrents WHERE torrent_id = ?")
+            .bind(torrent_id)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|_| database::Error::TorrentNotFound)
     }
 
     async fn get_torrent_info_from_info_hash(&self, info_hash: &InfoHash) -> Result<DbTorrentInfo, database::Error> {
-        query_as::<_, DbTorrentInfo>(
-            "SELECT torrent_id, info_hash, name, pieces, piece_length, private, root_hash FROM torrust_torrents WHERE info_hash = ?",
-        )
-        .bind(info_hash.to_hex_string().to_lowercase())
-        .fetch_one(&self.pool)
-        .await
-        .map_err(|_| database::Error::TorrentNotFound)
+        query_as::<_, DbTorrentInfo>("SELECT * FROM torrust_torrents WHERE info_hash = ?")
+            .bind(info_hash.to_hex_string().to_lowercase())
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|_| database::Error::TorrentNotFound)
     }
 
     async fn get_torrent_files_from_id(&self, torrent_id: i64) -> Result<Vec<TorrentFile>, database::Error> {
@@ -695,7 +718,16 @@ impl Database for Sqlite {
 
     async fn get_torrent_listing_from_id(&self, torrent_id: i64) -> Result<TorrentListing, database::Error> {
         query_as::<_, TorrentListing>(
-            "SELECT tt.torrent_id, tp.username AS uploader, tt.info_hash, ti.title, ti.description, tt.category_id, tt.date_uploaded, tt.size AS file_size, tt.name,
+            "SELECT 
+            tt.torrent_id,
+            tp.username AS uploader,
+            tt.info_hash, ti.title,
+            ti.description,
+            tt.category_id,
+            tt.date_uploaded,
+            tt.size AS file_size,
+            tt.name,
+            tt.comment,
             CAST(COALESCE(sum(ts.seeders),0) as signed) as seeders,
             CAST(COALESCE(sum(ts.leechers),0) as signed) as leechers
             FROM torrust_torrents tt
@@ -703,17 +735,26 @@ impl Database for Sqlite {
             INNER JOIN torrust_torrent_info ti ON tt.torrent_id = ti.torrent_id
             LEFT JOIN torrust_torrent_tracker_stats ts ON tt.torrent_id = ts.torrent_id
             WHERE tt.torrent_id = ?
-            GROUP BY ts.torrent_id"
+            GROUP BY ts.torrent_id",
         )
-            .bind(torrent_id)
-            .fetch_one(&self.pool)
-            .await
-            .map_err(|_| database::Error::TorrentNotFound)
+        .bind(torrent_id)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|_| database::Error::TorrentNotFound)
     }
 
     async fn get_torrent_listing_from_info_hash(&self, info_hash: &InfoHash) -> Result<TorrentListing, database::Error> {
         query_as::<_, TorrentListing>(
-            "SELECT tt.torrent_id, tp.username AS uploader, tt.info_hash, ti.title, ti.description, tt.category_id, tt.date_uploaded, tt.size AS file_size, tt.name,
+            "SELECT
+            tt.torrent_id,
+            tp.username AS uploader,
+            tt.info_hash, ti.title,
+            ti.description,
+            tt.category_id,
+            tt.date_uploaded,
+            tt.size AS file_size,
+            tt.name,
+            tt.comment,
             CAST(COALESCE(sum(ts.seeders),0) as signed) as seeders,
             CAST(COALESCE(sum(ts.leechers),0) as signed) as leechers
             FROM torrust_torrents tt
@@ -721,12 +762,12 @@ impl Database for Sqlite {
             INNER JOIN torrust_torrent_info ti ON tt.torrent_id = ti.torrent_id
             LEFT JOIN torrust_torrent_tracker_stats ts ON tt.torrent_id = ts.torrent_id
             WHERE tt.info_hash = ?
-            GROUP BY ts.torrent_id"
+            GROUP BY ts.torrent_id",
         )
-            .bind(info_hash.to_string().to_lowercase())
-            .fetch_one(&self.pool)
-            .await
-            .map_err(|_| database::Error::TorrentNotFound)
+        .bind(info_hash.to_string().to_lowercase())
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|_| database::Error::TorrentNotFound)
     }
 
     async fn get_all_torrents_compact(&self) -> Result<Vec<TorrentCompact>, database::Error> {

--- a/src/databases/sqlite.rs
+++ b/src/databases/sqlite.rs
@@ -13,7 +13,7 @@ use crate::models::category::CategoryId;
 use crate::models::info_hash::InfoHash;
 use crate::models::response::TorrentsResponse;
 use crate::models::torrent::TorrentListing;
-use crate::models::torrent_file::{DbTorrentAnnounceUrl, DbTorrentFile, DbTorrentInfo, Torrent, TorrentFile};
+use crate::models::torrent_file::{DbTorrent, DbTorrentAnnounceUrl, DbTorrentFile, Torrent, TorrentFile};
 use crate::models::torrent_tag::{TagId, TorrentTag};
 use crate::models::tracker_key::TrackerKey;
 use crate::models::user::{User, UserAuthentication, UserCompact, UserId, UserProfile};
@@ -666,16 +666,16 @@ impl Database for Sqlite {
             .map_err(|err| database::Error::ErrorWithText(err.to_string()))
     }
 
-    async fn get_torrent_info_from_id(&self, torrent_id: i64) -> Result<DbTorrentInfo, database::Error> {
-        query_as::<_, DbTorrentInfo>("SELECT * FROM torrust_torrents WHERE torrent_id = ?")
+    async fn get_torrent_info_from_id(&self, torrent_id: i64) -> Result<DbTorrent, database::Error> {
+        query_as::<_, DbTorrent>("SELECT * FROM torrust_torrents WHERE torrent_id = ?")
             .bind(torrent_id)
             .fetch_one(&self.pool)
             .await
             .map_err(|_| database::Error::TorrentNotFound)
     }
 
-    async fn get_torrent_info_from_info_hash(&self, info_hash: &InfoHash) -> Result<DbTorrentInfo, database::Error> {
-        query_as::<_, DbTorrentInfo>("SELECT * FROM torrust_torrents WHERE info_hash = ?")
+    async fn get_torrent_info_from_info_hash(&self, info_hash: &InfoHash) -> Result<DbTorrent, database::Error> {
+        query_as::<_, DbTorrent>("SELECT * FROM torrust_torrents WHERE info_hash = ?")
             .bind(info_hash.to_hex_string().to_lowercase())
             .fetch_one(&self.pool)
             .await

--- a/src/models/response.rs
+++ b/src/models/response.rs
@@ -62,6 +62,7 @@ pub struct TorrentResponse {
     pub magnet_link: String,
     pub tags: Vec<TorrentTag>,
     pub name: String,
+    pub comment: Option<String>,
 }
 
 impl TorrentResponse {
@@ -83,6 +84,7 @@ impl TorrentResponse {
             magnet_link: String::new(),
             tags: vec![],
             name: torrent_listing.name,
+            comment: torrent_listing.comment,
         }
     }
 }

--- a/src/models/torrent.rs
+++ b/src/models/torrent.rs
@@ -21,6 +21,7 @@ pub struct TorrentListing {
     pub seeders: i64,
     pub leechers: i64,
     pub name: String,
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/models/torrent_file.rs
+++ b/src/models/torrent_file.rs
@@ -216,6 +216,7 @@ impl TorrentInfoDictionary {
 
         // a torrent file has a root hash or a pieces key, but not both.
         if root_hash > 0 {
+            // If `root_hash` is true the `pieces` field contains the `root hash`
             info_dict.root_hash = Some(pieces.to_owned());
         } else {
             let buffer = into_bytes(pieces).expect("variable `torrent_info.pieces` is not a valid hex string");

--- a/src/models/torrent_file.rs
+++ b/src/models/torrent_file.rs
@@ -5,7 +5,6 @@ use sha1::{Digest, Sha1};
 
 use super::info_hash::InfoHash;
 use crate::config::Configuration;
-use crate::services::torrent_file::CreateTorrentRequest;
 use crate::utils::hex::{from_bytes, into_bytes};
 
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
@@ -68,28 +67,6 @@ pub struct TorrentFile {
 }
 
 impl Torrent {
-    /// It builds a `Torrent` from a request.
-    ///
-    /// # Panics
-    ///
-    /// This function will panic if the `torrent_info.pieces` is not a valid hex string.
-    #[must_use]
-    pub fn from_request(create_torrent_req: CreateTorrentRequest) -> Self {
-        let info_dict = create_torrent_req.build_info_dictionary();
-
-        Self {
-            info: info_dict,
-            announce: None,
-            nodes: None,
-            encoding: None,
-            httpseeds: None,
-            announce_list: Some(create_torrent_req.announce_urls),
-            creation_date: None,
-            comment: create_torrent_req.comment,
-            created_by: None,
-        }
-    }
-
     /// It hydrates a `Torrent` struct from the database data.
     ///
     /// # Panics

--- a/src/models/torrent_file.rs
+++ b/src/models/torrent_file.rs
@@ -98,7 +98,7 @@ pub struct Torrent {
     #[serde(default)]
     #[serde(rename = "creation date")]
     pub creation_date: Option<i64>,
-    #[serde(rename = "comment")]
+    #[serde(default)]
     pub comment: Option<String>,
     #[serde(default)]
     #[serde(rename = "created by")]
@@ -171,7 +171,7 @@ impl Torrent {
             httpseeds: None,
             announce_list: Some(torrent_info.announce_urls),
             creation_date: None,
-            comment: None,
+            comment: torrent_info.comment,
             created_by: None,
         }
     }
@@ -191,6 +191,7 @@ impl Torrent {
             root_hash: torrent_info.root_hash,
             files: torrent_files,
             announce_urls: torrent_announce_urls,
+            comment: torrent_info.comment,
         };
         Torrent::from_new_torrent_info_request(torrent_info_request)
     }
@@ -296,6 +297,7 @@ pub struct DbTorrentInfo {
     #[serde(default)]
     pub private: Option<u8>,
     pub root_hash: i64,
+    pub comment: Option<String>,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]

--- a/src/services/torrent.rs
+++ b/src/services/torrent.rs
@@ -13,7 +13,7 @@ use crate::models::category::CategoryId;
 use crate::models::info_hash::InfoHash;
 use crate::models::response::{DeletedTorrentResponse, TorrentResponse, TorrentsResponse};
 use crate::models::torrent::{Metadata, TorrentId, TorrentListing};
-use crate::models::torrent_file::{DbTorrentInfo, Torrent, TorrentFile};
+use crate::models::torrent_file::{DbTorrent, Torrent, TorrentFile};
 use crate::models::torrent_tag::{TagId, TorrentTag};
 use crate::models::user::UserId;
 use crate::tracker::statistics_importer::StatisticsImporter;
@@ -649,7 +649,7 @@ impl DbTorrentInfoRepository {
     /// # Errors
     ///
     /// This function will return an error there is a database error.
-    pub async fn get_by_info_hash(&self, info_hash: &InfoHash) -> Result<DbTorrentInfo, Error> {
+    pub async fn get_by_info_hash(&self, info_hash: &InfoHash) -> Result<DbTorrent, Error> {
         self.database.get_torrent_info_from_info_hash(info_hash).await
     }
 

--- a/src/services/torrent_file.rs
+++ b/src/services/torrent_file.rs
@@ -9,13 +9,16 @@ use crate::services::hasher::sha1;
 /// It's not the full in-memory representation of a torrent file. The full
 /// in-memory representation is the `Torrent` struct.
 pub struct NewTorrentInfoRequest {
+    // The `info` dictionary fields
     pub name: String,
     pub pieces: String,
     pub piece_length: i64,
     pub private: Option<u8>,
     pub root_hash: i64,
     pub files: Vec<TorrentFile>,
+    // Other fields of the root level metainfo dictionary
     pub announce_urls: Vec<Vec<String>>,
+    pub comment: Option<String>,
 }
 
 /// It generates a random single-file torrent for testing purposes.
@@ -48,6 +51,7 @@ pub fn generate_random_torrent(id: Uuid) -> Torrent {
         root_hash: 0,
         files: torrent_files,
         announce_urls: torrent_announce_urls,
+        comment: None,
     };
 
     Torrent::from_new_torrent_info_request(torrent_info_request)

--- a/src/services/torrent_file.rs
+++ b/src/services/torrent_file.rs
@@ -14,7 +14,7 @@ pub struct CreateTorrentRequest {
     pub pieces: String,
     pub piece_length: i64,
     pub private: Option<u8>,
-    pub root_hash: i64,
+    pub root_hash: i64, // True (1) if it's a BEP 30 torrent.
     pub files: Vec<TorrentFile>,
     // Other fields of the root level metainfo dictionary
     pub announce_urls: Vec<Vec<String>>,

--- a/src/services/torrent_file.rs
+++ b/src/services/torrent_file.rs
@@ -1,14 +1,16 @@
 //! This module contains the services related to torrent file management.
+use serde_bytes::ByteBuf;
 use uuid::Uuid;
 
-use crate::models::torrent_file::{Torrent, TorrentFile};
+use crate::models::torrent_file::{Torrent, TorrentFile, TorrentInfoDictionary};
 use crate::services::hasher::sha1;
+use crate::utils::hex::into_bytes;
 
 /// It contains the information required to create a new torrent file.
 ///
 /// It's not the full in-memory representation of a torrent file. The full
 /// in-memory representation is the `Torrent` struct.
-pub struct NewTorrentInfoRequest {
+pub struct CreateTorrentRequest {
     // The `info` dictionary fields
     pub name: String,
     pub pieces: String,
@@ -19,6 +21,67 @@ pub struct NewTorrentInfoRequest {
     // Other fields of the root level metainfo dictionary
     pub announce_urls: Vec<Vec<String>>,
     pub comment: Option<String>,
+}
+
+impl CreateTorrentRequest {
+    /// It builds a `TorrentInfoDictionary` from the current torrent request.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the `pieces` field is not a valid hex string.
+    #[must_use]
+    pub fn build_info_dictionary(&self) -> TorrentInfoDictionary {
+        let mut info_dict = TorrentInfoDictionary {
+            name: self.name.to_string(),
+            pieces: None,
+            piece_length: self.piece_length,
+            md5sum: None,
+            length: None,
+            files: None,
+            private: self.private,
+            path: None,
+            root_hash: None,
+            source: None,
+        };
+
+        // a torrent file has a root hash or a pieces key, but not both.
+        if self.root_hash > 0 {
+            info_dict.root_hash = Some(self.pieces.clone());
+        } else {
+            let buffer = into_bytes(&self.pieces).expect("variable `torrent_info.pieces` is not a valid hex string");
+            info_dict.pieces = Some(ByteBuf::from(buffer));
+        }
+
+        // either set the single file or the multiple files information
+        if self.files.len() == 1 {
+            let torrent_file = self
+                .files
+                .first()
+                .expect("vector `torrent_files` should have at least one element");
+
+            info_dict.md5sum = torrent_file.md5sum.clone();
+
+            info_dict.length = Some(torrent_file.length);
+
+            let path = if torrent_file
+                .path
+                .first()
+                .as_ref()
+                .expect("the vector for the `path` should have at least one element")
+                .is_empty()
+            {
+                None
+            } else {
+                Some(torrent_file.path.clone())
+            };
+
+            info_dict.path = path;
+        } else {
+            info_dict.files = Some(self.files.clone());
+        }
+
+        info_dict
+    }
 }
 
 /// It generates a random single-file torrent for testing purposes.
@@ -43,7 +106,7 @@ pub fn generate_random_torrent(id: Uuid) -> Torrent {
 
     let torrent_announce_urls: Vec<Vec<String>> = vec![];
 
-    let torrent_info_request = NewTorrentInfoRequest {
+    let torrent_info_request = CreateTorrentRequest {
         name: format!("file-{id}.txt"),
         pieces: sha1(&file_contents),
         piece_length: 16384,
@@ -54,7 +117,7 @@ pub fn generate_random_torrent(id: Uuid) -> Torrent {
         comment: None,
     };
 
-    Torrent::from_new_torrent_info_request(torrent_info_request)
+    Torrent::from_request(torrent_info_request)
 }
 
 #[cfg(test)]
@@ -62,7 +125,7 @@ mod tests {
     use serde_bytes::ByteBuf;
     use uuid::Uuid;
 
-    use crate::models::torrent_file::{Torrent, TorrentInfo};
+    use crate::models::torrent_file::{Torrent, TorrentInfoDictionary};
     use crate::services::torrent_file::generate_random_torrent;
 
     #[test]
@@ -72,7 +135,7 @@ mod tests {
         let torrent = generate_random_torrent(uuid);
 
         let expected_torrent = Torrent {
-            info: TorrentInfo {
+            info: TorrentInfoDictionary {
                 name: "file-d6170378-2c14-4ccc-870d-2a8e15195e23.txt".to_string(),
                 pieces: Some(ByteBuf::from(vec![
                     62, 231, 243, 51, 234, 165, 204, 209, 51, 132, 163, 133, 249, 50, 107, 46, 24, 15, 251, 32,

--- a/src/services/torrent_file.rs
+++ b/src/services/torrent_file.rs
@@ -1,10 +1,8 @@
 //! This module contains the services related to torrent file management.
-use serde_bytes::ByteBuf;
 use uuid::Uuid;
 
 use crate::models::torrent_file::{Torrent, TorrentFile, TorrentInfoDictionary};
 use crate::services::hasher::sha1;
-use crate::utils::hex::into_bytes;
 
 /// It contains the information required to create a new torrent file.
 ///
@@ -31,56 +29,14 @@ impl CreateTorrentRequest {
     /// This function will panic if the `pieces` field is not a valid hex string.
     #[must_use]
     pub fn build_info_dictionary(&self) -> TorrentInfoDictionary {
-        let mut info_dict = TorrentInfoDictionary {
-            name: self.name.to_string(),
-            pieces: None,
-            piece_length: self.piece_length,
-            md5sum: None,
-            length: None,
-            files: None,
-            private: self.private,
-            path: None,
-            root_hash: None,
-            source: None,
-        };
-
-        // a torrent file has a root hash or a pieces key, but not both.
-        if self.root_hash > 0 {
-            info_dict.root_hash = Some(self.pieces.clone());
-        } else {
-            let buffer = into_bytes(&self.pieces).expect("variable `torrent_info.pieces` is not a valid hex string");
-            info_dict.pieces = Some(ByteBuf::from(buffer));
-        }
-
-        // either set the single file or the multiple files information
-        if self.files.len() == 1 {
-            let torrent_file = self
-                .files
-                .first()
-                .expect("vector `torrent_files` should have at least one element");
-
-            info_dict.md5sum = torrent_file.md5sum.clone();
-
-            info_dict.length = Some(torrent_file.length);
-
-            let path = if torrent_file
-                .path
-                .first()
-                .as_ref()
-                .expect("the vector for the `path` should have at least one element")
-                .is_empty()
-            {
-                None
-            } else {
-                Some(torrent_file.path.clone())
-            };
-
-            info_dict.path = path;
-        } else {
-            info_dict.files = Some(self.files.clone());
-        }
-
-        info_dict
+        TorrentInfoDictionary::with(
+            &self.name,
+            self.piece_length,
+            self.private,
+            self.root_hash,
+            &self.pieces,
+            &self.files,
+        )
     }
 }
 

--- a/src/services/torrent_file.rs
+++ b/src/services/torrent_file.rs
@@ -22,13 +22,35 @@ pub struct CreateTorrentRequest {
 }
 
 impl CreateTorrentRequest {
+    /// It builds a `Torrent` from a request.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the `torrent_info.pieces` is not a valid hex string.
+    #[must_use]
+    pub fn build_torrent(&self) -> Torrent {
+        let info_dict = self.build_info_dictionary();
+
+        Torrent {
+            info: info_dict,
+            announce: None,
+            nodes: None,
+            encoding: None,
+            httpseeds: None,
+            announce_list: Some(self.announce_urls.clone()),
+            creation_date: None,
+            comment: self.comment.clone(),
+            created_by: None,
+        }
+    }
+
     /// It builds a `TorrentInfoDictionary` from the current torrent request.
     ///
     /// # Panics
     ///
     /// This function will panic if the `pieces` field is not a valid hex string.
     #[must_use]
-    pub fn build_info_dictionary(&self) -> TorrentInfoDictionary {
+    fn build_info_dictionary(&self) -> TorrentInfoDictionary {
         TorrentInfoDictionary::with(
             &self.name,
             self.piece_length,
@@ -62,7 +84,7 @@ pub fn generate_random_torrent(id: Uuid) -> Torrent {
 
     let torrent_announce_urls: Vec<Vec<String>> = vec![];
 
-    let torrent_info_request = CreateTorrentRequest {
+    let create_torrent_req = CreateTorrentRequest {
         name: format!("file-{id}.txt"),
         pieces: sha1(&file_contents),
         piece_length: 16384,
@@ -73,7 +95,7 @@ pub fn generate_random_torrent(id: Uuid) -> Torrent {
         comment: None,
     };
 
-    Torrent::from_request(torrent_info_request)
+    create_torrent_req.build_torrent()
 }
 
 #[cfg(test)]

--- a/src/upgrades/from_v1_0_0_to_v2_0_0/databases/sqlite_v2_0_0.rs
+++ b/src/upgrades/from_v1_0_0_to_v2_0_0/databases/sqlite_v2_0_0.rs
@@ -7,7 +7,7 @@ use sqlx::{query, query_as, SqlitePool};
 
 use super::sqlite_v1_0_0::{TorrentRecordV1, UserRecordV1};
 use crate::databases::database::{self, TABLES_TO_TRUNCATE};
-use crate::models::torrent_file::{TorrentFile, TorrentInfo};
+use crate::models::torrent_file::{TorrentFile, TorrentInfoDictionary};
 
 #[derive(Debug, Serialize, Deserialize, sqlx::FromRow)]
 pub struct CategoryRecordV2 {
@@ -32,7 +32,7 @@ pub struct TorrentRecordV2 {
 
 impl TorrentRecordV2 {
     #[must_use]
-    pub fn from_v1_data(torrent: &TorrentRecordV1, torrent_info: &TorrentInfo, uploader: &UserRecordV1) -> Self {
+    pub fn from_v1_data(torrent: &TorrentRecordV1, torrent_info: &TorrentInfoDictionary, uploader: &UserRecordV1) -> Self {
         Self {
             torrent_id: torrent.torrent_id,
             uploader_id: uploader.user_id,

--- a/tests/common/contexts/tag/fixtures.rs
+++ b/tests/common/contexts/tag/fixtures.rs
@@ -1,7 +1,7 @@
 use rand::Rng;
 
 pub fn random_tag_name() -> String {
-    format!("category name {}", random_id())
+    format!("tag name {}", random_id())
 }
 
 fn random_id() -> u64 {

--- a/tests/common/contexts/torrent/responses.rs
+++ b/tests/common/contexts/torrent/responses.rs
@@ -40,6 +40,7 @@ pub struct ListItem {
     pub seeders: i64,
     pub leechers: i64,
     pub name: String,
+    pub comment: Option<String>,
 }
 
 #[derive(Deserialize, PartialEq, Debug)]
@@ -64,6 +65,7 @@ pub struct TorrentDetails {
     pub magnet_link: String,
     pub tags: Vec<Tag>,
     pub name: String,
+    pub comment: Option<String>,
 }
 
 #[derive(Deserialize, PartialEq, Debug)]

--- a/tests/e2e/web/api/v1/contexts/torrent/contract.rs
+++ b/tests/e2e/web/api/v1/contexts/torrent/contract.rs
@@ -211,6 +211,7 @@ mod for_guests {
             ),
             tags: vec![],
             name: test_torrent.index_info.name.clone(),
+            comment: test_torrent.file_info.comment.clone(),
         };
 
         assert_expected_torrent_details(&torrent_details_response.data, &expected_torrent);


### PR DESCRIPTION
And add it to the API responses.

- Torrent details endpoint
- Torrent list endpoint
- Include the `comment` in the downloaded torrent